### PR TITLE
Fix compiler error (IDFGH-2926)

### DIFF
--- a/src/include/lwip/pbuf.h
+++ b/src/include/lwip/pbuf.h
@@ -40,6 +40,9 @@
 
 #include "lwip/opt.h"
 #include "lwip/err.h"
+#if ESP_LWIP
+#include "lwip/netif.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
missing struct netif definition