### PR TITLE
Adds #if PPP_AUTH_SUPPORT around call to ppp_set_auth() (IDFGH-2925)

### DIFF
--- a/src/netif/ppp/pppapi.c
+++ b/src/netif/ppp/pppapi.c
@@ -83,6 +83,7 @@ pppapi_set_default(ppp_pcb *pcb)
 }
 
 #if ESP_LWIP
+#if PPP_AUTH_SUPPORT
 /**
  * Call ppp_set_auth() inside the tcpip_thread context.
  */
@@ -110,8 +111,8 @@ pppapi_set_auth(ppp_pcb *pcb, u8_t authtype, const char *user, const char *passw
   msg.msg.msg.setauth.passwd = passwd;
   tcpip_api_call(pppapi_do_ppp_set_auth, &msg.call);
 }
-
-#endif
+#endif /* PPP_AUTH_SUPPORT */
+#endif /* ESP_LWIP */
 
 #if PPP_NOTIFY_PHASE
 /**


### PR DESCRIPTION
to avoid undefined function error.
ppp.h ppp_set_auth() definition is wrapped by PPP_AUTH_SUPPORT check. If PPP_SUPPORT is enabled and PPP_AUTH_SUPPORT is disabled, ppp_set_auth() is not a defined function.