### PR TITLE
pbuf: Include lwip/netif.h to fix compile error

### DIFF
--- a/src/core/pbuf.c
+++ b/src/core/pbuf.c
@@ -123,6 +123,9 @@ void eth_rx_irq()
 #if LWIP_CHECKSUM_ON_COPY
 #include "lwip/inet_chksum.h"
 #endif
+#if ESP_LWIP
+#include "lwip/netif.h"
+#endif
 
 #include <string.h>
 


### PR DESCRIPTION
Fixes compile error when CONFIG_TCP_QUEUE_OOSEQ is not set.

Signed-off-by: Axel Lin <axel.lin@ingics.com>