### PR TITLE
ipv6: fix ndp dns option to work with esp-idf (IDFGH-2924)

### DIFF
--- a/src/core/ipv6/nd6.c
+++ b/src/core/ipv6/nd6.c
@@ -562,8 +562,13 @@ nd6_input(struct pbuf *p, struct netif *inp)
             /* TODO implement DNS removal in dns.c */
             u8_t s;
             for (s = 0; s < DNS_MAX_SERVERS; s++) {
+#ifdef ESP_LWIP
+              ip_addr_t addr = dns_getserver(s);
+              if(ip_addr_cmp(&addr, &rdnss_address)) {
+#else
               const ip_addr_t *addr = dns_getserver(s);
               if(ip_addr_cmp(addr, &rdnss_address)) {
+#endif
                 dns_setserver(s, NULL);
               }
             }


### PR DESCRIPTION
Fix minor compilation/type issue for esp-idf version of NDP implementation (type of dns_getserver changed from returning const ip_addr_t* to ip_addr_t)