### PR TITLE
core/ipv4/dhcp: add hostname option to dhcp request on reboot (IDFGH-3013)

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1393,6 +1393,10 @@ dhcp_reboot(struct netif *netif)
       dhcp_option_byte(dhcp, dhcp_discover_request_options[i]);
     }
 
+#if LWIP_NETIF_HOSTNAME
+    dhcp_option_hostname(dhcp, netif);
+#endif /* LWIP_NETIF_HOSTNAME */
+
     dhcp_option_trailer(dhcp);
 
     pbuf_realloc(dhcp->p_out, sizeof(struct dhcp_msg) - DHCP_OPTIONS_LEN + dhcp->options_out_len);


### PR DESCRIPTION
Unfortunately the DHCP option "hostname" (12) wasn't set in the "reboot"
dhcp message until now. dhcp_reboot is executed in each of the following
cases: REBIND, RENEW, BOUND, REBOOTING
If the dhcp server uses the hostname option in order to create matching
dns records (which is common), it wasn't possible to change its DNS
record after its initial dhcp request.
The only possibility to change the hostname was to trigger a reboot
(or a dhcp_stop).

The recent changes of 3b88e84f9b05e76a1ad96e6650a795df74af23aa made the
situation even worse. Since the last valid ip address obtained from the
DHCP server is now stored in non-volatile storage, it was not even
possible to change the hostname with a reboot of the device, since even
then a dhcp_reboot message (with the hostname option missing) is sent
(instead of a fresh dhcp request).

This fix is already implemented in the upstream version of lwip:
http://git.savannah.nongnu.org/cgit/lwip.git/commit/?id=d65681a7d7a13a220c7bab9093c717b151d3719c