### PR TITLE
add support to LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK (IDFGH-4542)

### DIFF
--- a/src/core/netif.c
+++ b/src/core/netif.c
@@ -1308,3 +1308,34 @@ netif_null_output_ip6(struct netif *netif, struct pbuf *p, const ip6_addr_t *ipa
   return ERR_IF;
 }
 #endif /* LWIP_IPV6 */
+
+#ifdef LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK
+#include <esp_log.h>
+
+err_t eth_unknow_type_callback(struct pbuf* pbuf, struct netif* netif){
+	ESP_LOGE("LWIP","netif num: %d name: %s", netif->num,netif->name);
+	//ESP_LOG_BUFFER_HEX("LWIP",pbuf,sizeof(pbuf));
+	ESP_LOGE("LWIP","netif: %p,netif->eth_unknow_type_callback: %p",netif,netif->eth_unknow_type_callback);
+	if(netif->eth_unknow_type_callback_registered){
+		if(netif->eth_unknow_type_callback){
+			return netif->eth_unknow_type_callback(pbuf,netif);
+		}
+		return ERR_OK;
+	}
+	ESP_LOGE("LWIP","%s","YZX netif->eth_unknow_type_callback is NULL");
+	return ERR_OK;
+}
+
+err_t register_eth_unknow_type_callback(u8_t num,netif_input_fn p){
+	int length = sizeof(netif_list);
+	ESP_LOGE("LWIP","sizeof(netif_list): %d",length);
+	for(int i = 0 ; i < length ; i++){
+		if(netif_list[i].num == num){
+			netif_list[i].eth_unknow_type_callback_registered = true;
+			netif_list[i].eth_unknow_type_callback = p;
+			return ERR_OK;
+		}
+	}
+	return ERR_OK;
+}
+#endif

--- a/src/include/HOOKS.h
+++ b/src/include/HOOKS.h
@@ -1,0 +1,6 @@
+#ifdef LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK
+#include "lwip/netif.h"
+
+#define LWIP_HOOK_UNKNOWN_ETH_PROTOCOL eth_unknow_type_callback
+
+#endif

--- a/src/include/lwip/netif.h
+++ b/src/include/lwip/netif.h
@@ -363,6 +363,11 @@ struct netif {
   void (*l2_buffer_free_notify)(void *user_buf); /* Allows LWIP to notify driver when a L2-supplied pbuf can be freed */
   ip_addr_t last_ip_addr; /* Store last non-zero ip address */
 #endif
+
+#ifdef LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK
+netif_input_fn eth_unknow_type_callback;
+bool eth_unknow_type_callback_registered;
+#endif
 };
 
 #if LWIP_CHECKSUM_CTRL_PER_NETIF
@@ -500,6 +505,11 @@ err_t netif_add_ip6_address(struct netif *netif, const ip6_addr_t *ip6addr, s8_t
 #else /* LWIP_NETIF_HWADDRHINT */
 #define NETIF_SET_HWADDRHINT(netif, hint)
 #endif /* LWIP_NETIF_HWADDRHINT */
+
+#ifdef LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK
+err_t eth_unknow_type_callback(struct pbuf* pbuf, struct netif* netif);
+err_t register_eth_unknow_type_callback(u8_t num,netif_input_fn p);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -2434,9 +2434,10 @@
  * Declare your hook function prototypes in there, you may also #include all headers
  * providing data types that are need in this file.
  */
-#ifdef __DOXYGEN__
-#define LWIP_HOOK_FILENAME "path/to/my/lwip_hooks.h"
-#endif
+//ifdef __DOXYGEN__
+#define LWIP_HOOK_UNKNOWN_ETH_PROTOCOL_CALLBACK
+#define LWIP_HOOK_FILENAME "HOOKS.h"
+//#endif
 
 /**
  * LWIP_HOOK_TCP_ISN:


### PR DESCRIPTION
https://github.com/espressif/esp-idf/issues/3526

Wonder If  this is the right way,
Maybe useful for someone else.

I use https://github.com/espressif/arduino-esp32 ,
to test this,
replace netif.h and liblwip.a after using esp-idf to complie the example,
esp-idf/examples/ethernet/ethernet.

```C
err_t Callback(struct pbuf *p, struct netif *inp){
  log_e("Callback");
  ESP_LOG_BUFFER_HEX("Callback",p,sizeof(p));
}

register_eth_unknow_type_callback(1,&Callback);
```
IN
```C
err_t register_eth_unknow_type_callback(u8_t num,netif_input_fn p);
```
The num is the netif num,
0 for Wifi (Maybe)
1 For Eth  (I Use this)
