### PR TITLE
dhcp: Set hostname for DISCOVER packets (IDFGH-2922)

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -1057,6 +1057,10 @@ dhcp_discover(struct netif *netif)
     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_MAX_MSG_SIZE, DHCP_OPTION_MAX_MSG_SIZE_LEN);
     options_out_len = dhcp_option_short(options_out_len, msg_out->options, DHCP_MAX_MSG_LEN(netif));
 
+#if LWIP_NETIF_HOSTNAME
+    options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
+#endif /* LWIP NETIF HOSTNAME */
+
     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_PARAMETER_REQUEST_LIST, LWIP_ARRAYSIZE(dhcp_discover_request_options));
     for (i = 0; i < LWIP_ARRAYSIZE(dhcp_discover_request_options); i++) {
       options_out_len = dhcp_option_byte(options_out_len, msg_out->options, dhcp_discover_request_options[i]);


### PR DESCRIPTION
If the hostname is not set in the DISCOVER packet, then some servers might
issue an OFFER with that it will reject when the hostname is presented in
the REQUEST packet.

This is similar to commit 0865edf80ad0a96e0eaf2bbedbad350cab248115 which is in 2.0.3-esp release/v3.2 release/v3.3 but not 2.1.2-esp.

This PR is related to #6, but fixes a different issue.