### PR TITLE
pppapi: Add #if PPP_AUTH_SUPPORT guard for pppapi_set_auth() (IDFGH-2921)

### DIFF
--- a/src/include/netif/ppp/pppapi.h
+++ b/src/include/netif/ppp/pppapi.h
@@ -47,7 +47,7 @@ extern "C" {
 struct pppapi_msg_msg {
   ppp_pcb *ppp;
   union {
-#if ESP_PPP
+#if ESP_PPP && PPP_AUTH_SUPPORT
     struct {
       u8_t authtype;
       const char *user;
@@ -111,7 +111,7 @@ struct pppapi_msg {
 
 /* API for application */
 err_t pppapi_set_default(ppp_pcb *pcb);
-#if ESP_PPP
+#if ESP_PPP && PPP_AUTH_SUPPORT
 void pppapi_set_auth(ppp_pcb *pcb, u8_t authtype, const char *user, const char *passwd);
 #endif
 #if PPP_NOTIFY_PHASE

--- a/src/netif/ppp/pppapi.c
+++ b/src/netif/ppp/pppapi.c
@@ -82,7 +82,7 @@ pppapi_set_default(ppp_pcb *pcb)
   return err;
 }
 
-#if ESP_PPP
+#if ESP_PPP && PPP_AUTH_SUPPORT
 /**
  * Call ppp_set_auth() inside the tcpip_thread context.
  */


### PR DESCRIPTION
The ppp_set_auth() is guarded by PPP_AUTH_SUPPORT, so the pppapi_set_auth
and pppapi_do_ppp_set_auth should also use the same #if guard.

This fixes build error if ESP_PPP is set but both PAP and CHAP are disabled.

Signed-off-by: Axel Lin <axel.lin@gmail.com>