### PR TITLE
Prevent crash when socket lock not initialized

### DIFF
--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -348,6 +348,9 @@ sock_inc_used(struct lwip_sock *sock)
   LWIP_ASSERT("sock != NULL", sock != NULL);
 
 #if ESP_LWIP_LOCK
+  if (sock->lock == NULL) {
+    return 0;
+  }
   SYS_ARCH_PROTECT_SOCK(sock);
 #else
   SYS_ARCH_PROTECT(lev);


### PR DESCRIPTION
Crash occurs when running any socket related command (e.g. getsockopt) before a socket has been initialized for the first time.