### PR TITLE
sockets: Prevent crash when socket not initialized

### DIFF
--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -465,6 +465,10 @@ tryget_socket_unconn(int fd)
 {
   struct lwip_sock *ret = tryget_socket_unconn_nouse(fd);
   if (ret != NULL) {
+#if ESP_LWIP      
+    if (ret->conn == NULL)
+      return NULL;
+#endif /* ESP_LWIP */  
     if (!sock_inc_used(ret)) {
       return NULL;
     }


### PR DESCRIPTION
Updated to match tryget_socket_unconn_locked(), see https://github.com/espressif/esp-lwip/pull/11. @freakyxue 