### PR TITLE
igmp/mld6: Fix build warnings when !ESP_LWIP_IGMP/MLD6_TIMERS_ONDEMAND (IDFGH-3151)

### DIFF
--- a/src/core/ipv4/igmp.c
+++ b/src/core/ipv4/igmp.c
@@ -639,6 +639,7 @@ igmp_leavegroup_netif(struct netif *netif, const ip4_addr_t *groupaddr)
   }
 }
 
+#if ESP_LWIP_IGMP_TIMERS_ONDEMAND
 /**
  * Wrapper function with matching prototype which calls the actual callback
  */
@@ -648,6 +649,7 @@ static void igmp_timeout_cb(void *arg)
 
   igmp_tmr();
 }
+#endif
 /**
  * The igmp timer function (both for NO_SYS=1 and =0)
  * Should be called every IGMP_TMR_INTERVAL milliseconds (100 ms is default).

--- a/src/core/ipv6/mld6.c
+++ b/src/core/ipv6/mld6.c
@@ -490,6 +490,7 @@ mld6_leavegroup_netif(struct netif *netif, const ip6_addr_t *groupaddr)
   return ERR_VAL;
 }
 
+#if ESP_LWIP_MLD6_TIMERS_ONDEMAND
 /**
  * Wrapper function with matching prototype which calls the actual callback
  */
@@ -499,6 +500,7 @@ static void mld6_timeout_cb(void *arg)
 
   mld6_tmr();
 }
+#endif
 
 /**
  * Periodic timer for mld processing. Must be called every


### PR DESCRIPTION
Fix below build warnings:
warning: 'igmp_timeout_cb' defined but not used [-Wunused-function]
warning: 'mld6_timeout_cb' defined but not used [-Wunused-function]

Signed-off-by: Axel Lin <axel.lin@gmail.com>