### PR TITLE
Added weak symbol function for LWIP_HOOK_IP6_ROUTE (IDFGH-3967)

### DIFF
--- a/src/core/ipv6/ip6.c
+++ b/src/core/ipv6/ip6.c
@@ -65,6 +65,26 @@
 #endif
 
 /**
+ * This is an alternative way of declaring LWIP_HOOK_IP6_ROUTE.
+ * By default it links this weak function that is a no-op,
+ * but you can declare your own (without weak attribute) and
+ * override it during linking.
+ * 
+ * See https://en.wikipedia.org/wiki/Weak_symbol for more details on this mechanism.
+ * 
+ * @param src the source IPv6 address, if known
+ * @param dest the destination IPv6 address for which to find the route
+ * @return the netif on which to send to reach dest
+ */
+struct  netif* __weak
+lwip_hook_ip6_route(const ip6_addr_t *dest, const ip6_addr_t *src)
+{
+  LWIP_UNUSED_ARG(dest);
+  LWIP_UNUSED_ARG(src);
+  return NULL;
+}
+
+/**
  * Finds the appropriate network interface for a given IPv6 address. It tries to select
  * a netif following a sequence of heuristics:
  * 1) if there is only 1 netif, return it
@@ -186,6 +206,11 @@ ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest)
     return netif;
   }
 #endif
+
+  netif = lwip_hook_ip6_route(src, dest);
+  if (netif != NULL) {
+    return netif;
+  }
 
   /* See if the destination subnet matches a configured address. In accordance
    * with RFC 5942, dynamically configured addresses do not have an implied

--- a/src/include/lwip/def.h
+++ b/src/include/lwip/def.h
@@ -149,4 +149,7 @@ char* lwip_strnstr(const char* buffer, const char* token, size_t n);
 }
 #endif
 
+/* Provide an alias for non-standard attribute in case one needs to redefine it */
+#define __weak __attribute__((weak))
+
 #endif /* LWIP_HDR_DEF_H */

--- a/src/include/lwip/ip6.h
+++ b/src/include/lwip/ip6.h
@@ -57,6 +57,7 @@
 extern "C" {
 #endif
 
+struct  netif* __weak lwip_hook_ip6_route(const ip6_addr_t *dest, const ip6_addr_t *src);
 struct netif *ip6_route(const ip6_addr_t *src, const ip6_addr_t *dest);
 const ip_addr_t *ip6_select_source_address(struct netif *netif, const ip6_addr_t * dest);
 err_t         ip6_input(struct pbuf *p, struct netif *inp);


### PR DESCRIPTION
Recently I stumbled upon a project that requires overriding `LWIP_HOOK_IP6_ROUTE` in LwIP in `arduino-esp32`, however this was not possible due to the fact that in `arduino-esp32` all components from `esp-idf` come as a pre-compiled, static libraries.

This problem does not exist in most of the other projects utilizing LwIP as they're not using intermediate static libraries.

In this pull request you'll find my proposed solution using weak symbols. As described in the code - it will produce a no-op weak symbol in the library, that can still be overridden by a strong symbol declared by the user of `arduino-esp32` during **linking** time.

Such mechanism is used in many projects and seems like a reasonable solution of this problem to me.