### PR TITLE
Allow for slip input of longer than 256 bytes. (IDFGH-4019)

### DIFF
--- a/src/include/netif/slipif.h
+++ b/src/include/netif/slipif.h
@@ -76,7 +76,7 @@ void slipif_poll(struct netif *netif);
 #if SLIP_RX_FROM_ISR
 void slipif_process_rxqueue(struct netif *netif);
 void slipif_received_byte(struct netif *netif, u8_t data);
-void slipif_received_bytes(struct netif *netif, u8_t *data, u8_t len);
+void slipif_received_bytes(struct netif *netif, u8_t *data, u32_t len);
 #endif /* SLIP_RX_FROM_ISR */
 
 #ifdef __cplusplus

--- a/src/netif/slipif.c
+++ b/src/netif/slipif.c
@@ -544,9 +544,9 @@ slipif_received_byte(struct netif *netif, u8_t data)
  * @param len Number of received characters
  */
 void
-slipif_received_bytes(struct netif *netif, u8_t *data, u8_t len)
+slipif_received_bytes(struct netif *netif, u8_t *data, u32_t len)
 {
-  u8_t i;
+  u32_t i;
   u8_t *rxdata = data;
   LWIP_ASSERT("netif != NULL", (netif != NULL));
   LWIP_ASSERT("netif->state != NULL", (netif->state != NULL));


### PR DESCRIPTION
Allows SLIP interface to accept input of longer than 256 bytes in one go. Relevant to https://github.com/espressif/esp-idf/pull/4985, which will perform UART reads with a user defined (32-bit buffer length) and then attempt to write them into `slipif_received_bytes`.