### PR TITLE
pppos: fix in_tail null (IDFGH-4258)

### DIFF
--- a/src/netif/ppp/pppos.c
+++ b/src/netif/ppp/pppos.c
@@ -537,6 +537,12 @@ pppos_input(ppp_pcb *ppp, u8_t *s, int l)
           /* Note: If you get lots of these, check for UART frame errors or try different baud rate */
           LINK_STATS_INC(link.chkerr);
           pppos_input_drop(pppos);
+        } else if (!pppos->in_tail) {
+          PPPDEBUG(LOG_INFO,
+                   ("pppos_input[%d]: Dropping null in_tail\n",
+                    ppp->netif->num));
+          LINK_STATS_INC(link.drop);
+          pppos_input_drop(pppos);
         /* Otherwise it's a good packet so pass it on. */
         } else {
           struct pbuf *inp;


### PR DESCRIPTION
happens during quick reconnect of LTE ppp session