### PR TITLE
Fix SLIP RX linked list append. (IDFGH-4356)

### DIFF
--- a/src/netif/slipif.c
+++ b/src/netif/slipif.c
@@ -497,7 +497,7 @@ slipif_rxbyte_enqueue(struct netif *netif, u8_t data)
     if (priv->rxpackets != NULL) {
 #if SLIP_RX_QUEUE
       /* queue multiple pbufs */
-      struct pbuf *q = p;
+      struct pbuf *q = priv->rxpackets;
       while (q->next != NULL) {
         q = q->next;
       }


### PR DESCRIPTION
Append to the linked list of pbuf objects was broken so that the second
(and subsequent) packets received in a SLIP transaction would be
appended to themselves and consequently lost.

This resulted in these packets being dropped and the system suffering
extreme memory leakage.

/cc @ryankurte