### PR TITLE
Document that sntp_setservername doesn't copy the string (IDFGH-5714)

### DIFF
--- a/src/apps/sntp/sntp.c
+++ b/src/apps/sntp/sntp.c
@@ -867,7 +867,8 @@ sntp_getserver(u8_t idx)
  * Initialize one of the NTP servers by name
  *
  * @param idx the index of the NTP server to set must be < SNTP_MAX_SERVERS
- * @param server DNS name of the NTP server to set, to be resolved at contact time
+ * @param server DNS name of the NTP server to set, to be resolved at contact
+ *        time.  Note sntp stores the pointer, it doesn't copy the string.
  */
 void
 sntp_setservername(u8_t idx, const char *server)


### PR DESCRIPTION
I was expecting the string to be duplicate, doing a Google search
shows others did as well.