### PR TITLE
Add SO_EXCEPTION to set/getsockopt() (IDFGH-6195)

### DIFF
--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -467,7 +467,7 @@ err_tcp(void *arg, err_t err)
   SYS_ARCH_UNPROTECT(lev);
 
   /* Notify the user layer about a connection error. Used to signal select. */
-  API_EVENT(conn, NETCONN_EVT_ERROR, 0);
+  API_EVENT(conn, NETCONN_EVT_ERROR, -1);
   /* Try to release selects pending on 'read' or 'write', too.
      They will get an error if they actually try to read or write. */
   API_EVENT(conn, NETCONN_EVT_RCVPLUS, 0);
@@ -1107,7 +1107,7 @@ lwip_netconn_do_close_internal(struct netconn *conn  WRITE_DELAYED_PARAM)
         conn->pcb.tcp = NULL;
         /* Trigger select() in socket layer. Make sure everybody notices activity
          on the connection, error first! */
-        API_EVENT(conn, NETCONN_EVT_ERROR, 0);
+        API_EVENT(conn, NETCONN_EVT_ERROR, -1);
       }
       if (shut_rx) {
         API_EVENT(conn, NETCONN_EVT_RCVPLUS, 0);

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -3064,6 +3064,8 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
           *(int *)optval = sock->errevent;
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, SOL_SOCKET, SO_EXCEPTION) = %d\n",
                                       s, *(int *)optval));
+          /* Clearing exception */
+          API_EVENT(sock->conn, NETCONN_EVT_ERROR, 0);
           break;
 
 #if LWIP_SO_SNDTIMEO

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -219,6 +219,7 @@ struct ifreq {
 #define SO_CONTIMEO     0x1009 /* Unimplemented: connect timeout */
 #define SO_NO_CHECK     0x100a /* don't create UDP checksum */
 #define SO_BINDTODEVICE 0x100b /* bind to device */
+#define SO_EXCEPTION    0x100c /* socket exception */
 
 /*
  * Structure used for manipulating linger option.


### PR DESCRIPTION
This feature works similarly to RTCS's SO_EXCEPTION. Setting an SO_EXCEPTION value for a socket using setsockopt() breaks out from blocking select() calls and puts the socket into the returned exception fd_set. The exception value can be read using getsockopt(). Reading SO_EXCEPTION with getsockopt() clears the exception.

Example usage:

```
    fd_set readfds;
    fd_set exceptfds;

    FD_ZERO(&readfds);
    FD_SET(sockfd, &readfds);

    FD_ZERO(&exceptfds);
    FD_SET(sockfd, &exceptfds);

    int res = select(sockfd + 1, &readfds, NULL, &exceptfds, NULL);
    if (res < 0) {
        return -1;
    } else if (res == 0) {
        return 0;
    }

    int exception;
    socklen_t len = sizeof(int);

    if (FD_ISSET(sockfd, &exceptfds)) {
        // Reading the exception value. Note that this also clears the value.
        if (getsockopt(sockfd, SOL_SOCKET, SO_EXCEPTION, (void *)&exception, &len) < 0) {
            return -1;
        }

        printf("select exception %d\n", exception); // This will display the exception value set by setsockopt(sockfd, SOL_SOCKET, SO_EXCEPTION, (void *)&value, sizeof(int));

        ... do something useful here ...
    }

    if (FD_ISSET(sockfd, &readfds)) {
       ... handle read from sockfd in case it has bytes available ...
    }
```