### PR TITLE
Lwip with port forwarding on same netif (IDFGH-6860)

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -365,13 +365,14 @@ static void
 dhcp_handle_offer(struct netif *netif, struct dhcp_msg *msg_in)
 {
   struct dhcp *dhcp = netif_dhcp_data(netif);
+  u8_t n;
 
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp_handle_offer(netif=%p) %c%c%"U16_F"\n",
               (void *)netif, netif->name[0], netif->name[1], (u16_t)netif->num));
 
   /* Vendor Specific Information */
 #if ESP_DHCP && !ESP_DHCP_DISABLE_VENDOR_CLASS_IDENTIFIER
-  for (u8_t n = 0; (n < DHCP_OPTION_VSI_MAX) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_VSI + n); n++) {
+  for (n = 0; (n < DHCP_OPTION_VSI_MAX) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_VSI + n); n++) {
     dhcp_option_vsi[n] = lwip_htonl(dhcp_get_option_value(dhcp, DHCP_OPTION_IDX_VSI + n));
   }
 #endif /* ESP_DHCP && !ESP_DHCP_DISABLE_VENDOR_CLASS_IDENTIFIER */

--- a/src/core/ipv4/ip4_napt.c
+++ b/src/core/ipv4/ip4_napt.c
@@ -39,9 +39,11 @@
  *
  */
 
-#if ESP_LWIP
-#if LWIP_IPV4
-#if IP_NAPT
+#if ESP_LWIP && LWIP_IPV4 && IP_NAPT
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
 
 #include "lwip/sys.h"
 #include "lwip/ip.h"
@@ -53,31 +55,38 @@
 #include "lwip/priv/tcp_priv.h"
 #include "lwip/lwip_napt.h"
 #include "lwip/ip4_napt.h"
-#include "string.h"
-#include "assert.h"
+#include "lwip/timeouts.h"
 
 #define NO_IDX ((u16_t)-1)
 #define NT(x) ((x) == NO_IDX ? NULL : &ip_napt_table[x])
 
-struct napt_table {
+#pragma GCC diagnostic push
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wc90-c99-compat" /* To allow u8_t bit fields */
+#endif
+struct ip_napt_entry {
   u32_t last;
-  u32_t src;
-  u32_t dest;
-  u16_t sport;
-  u16_t dport;
-  u16_t msport;
-  u16_t mdport;
+  u32_t src;   /* net */
+  u32_t dest;  /* net */
+  u16_t sport; /* net */
+  u16_t dport; /* net */
+  u16_t msport; /* net */
+  u16_t mdport; /* net */
   u8_t proto;
-  unsigned int fin1 : 1;
-  unsigned int fin2 : 1;
-  unsigned int finack1 : 1;
-  unsigned int finack2 : 1;
-  unsigned int synack : 1;
-  unsigned int rst : 1;
+  u8_t fin1 : 1;
+  u8_t fin2 : 1;
+  u8_t finack1 : 1;
+  u8_t finack2 : 1;
+  u8_t synack : 1;
+  u8_t rst : 1;
+  u8_t _unused : 2;
+  u32_t src_seqno;  /* host */
+  u32_t dest_seqno; /* host */
   u16_t next, prev;
 };
+#pragma GCC diagnostic pop
 
-struct portmap_table {
+struct ip_portmap_entry {
   u32_t maddr;
   u32_t daddr;
   u16_t mport;
@@ -87,52 +96,68 @@ struct portmap_table {
 };
 
 static u16_t napt_list = NO_IDX, napt_list_last = NO_IDX, napt_free = 0;
+static u8_t ip_portmap_max = 0;
 
-static struct napt_table *ip_napt_table = NULL;
-static struct portmap_table *ip_portmap_table = NULL;
+static struct ip_napt_entry *ip_napt_table = NULL;
+static struct ip_portmap_entry *ip_portmap_table = NULL;
 
-static int nr_active_napt_tcp = 0, nr_active_napt_udp = 0, nr_active_napt_icmp = 0;
-static uint16_t ip_napt_max = 0;
-static uint8_t ip_portmap_max = 0;
+static struct ip_napt_stats napt_stats;
+
+static void ip_napt_gc(uint32_t now, bool force);
+static void ip_napt_tmr(void *arg);
+
+#define WRAPPED_AROUND(a, b) ((((a) ^ (b)) & (1UL << 31)) != 0)
 
 #if NAPT_DEBUG
-/* Print NAPT table using LWIP_DEBUGF
-*/
+/* Print NAPT table using LWIP_DEBUGF */
+#define DPRINTF(m) LWIP_DEBUGF(NAPT_DEBUG, m)
+/* #define DPRINTF(m) printf m */
 static void
 napt_debug_print(void)
 {
-  int i, next;
-  LWIP_DEBUGF(NAPT_DEBUG, ("NAPT table:\n"));
-  LWIP_DEBUGF(NAPT_DEBUG, (" proto src                     dest                    sport   dport   msport  mdport \n"));
-  LWIP_DEBUGF(NAPT_DEBUG, ("+-----+-----------------------+-----------------------+-------+-------+-------+-------+\n"));
+  int i, next, p;
+  u32_t now = sys_now();
+  u32_t nr_total = napt_stats.nr_active_tcp + napt_stats.nr_active_udp + napt_stats.nr_active_icmp;
+  DPRINTF(("NAPT table (%"U16_F"+%"U16_F"+%"U16_F"=%"U32_F" / %"U16_F"):\n",
+           napt_stats.nr_active_tcp, napt_stats.nr_active_udp, napt_stats.nr_active_icmp, nr_total, napt_stats.max_entries));
+  if (nr_total == 0) return;
 
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
+  DPRINTF(("| src                   | dest                  | msport| mdport| flags   | age      |\n"));
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
   for (i = napt_list; i != NO_IDX; i = next) {
-     struct napt_table *t = &ip_napt_table[i];
+     struct ip_napt_entry *t = &ip_napt_table[i];
      next = t->next;
 
-    if (t->proto == IP_PROTO_TCP) LWIP_DEBUGF(NAPT_DEBUG, ("| TCP "));
-    if (t->proto == IP_PROTO_UDP) LWIP_DEBUGF(NAPT_DEBUG, ("| UDP "));
-    if (t->proto == IP_PROTO_ICMP) LWIP_DEBUGF(NAPT_DEBUG, ("| ICMP"));
+     DPRINTF(("| %3"U16_F".%3"U16_F".%3"U16_F".%3"U16_F":%5"U16_F" ",
+              ((const u8_t*) (&t->src))[0],
+              ((const u8_t*) (&t->src))[1],
+              ((const u8_t*) (&t->src))[2],
+              ((const u8_t*) (&t->src))[3],
+              lwip_ntohs(t->sport)));
 
-     LWIP_DEBUGF(NAPT_DEBUG, ("| %3"U16_F" | %3"U16_F" | %3"U16_F" | %3"U16_F" |",
-			      ((const u8_t*) (&t->src))[0],
-			      ((const u8_t*) (&t->src))[1],
-			      ((const u8_t*) (&t->src))[2],
-			      ((const u8_t*) (&t->src))[3]));
+     DPRINTF(("| %3"U16_F".%3"U16_F".%3"U16_F".%3"U16_F":%5"U16_F" ",
+              ((const u8_t*) (&t->dest))[0],
+              ((const u8_t*) (&t->dest))[1],
+              ((const u8_t*) (&t->dest))[2],
+              ((const u8_t*) (&t->dest))[3],
+              lwip_ntohs(t->dport)));
 
-     LWIP_DEBUGF(NAPT_DEBUG, (" %3"U16_F" | %3"U16_F" | %3"U16_F" | %3"U16_F" |",
-			      ((const u8_t*) (&t->dest))[0],
-			      ((const u8_t*) (&t->dest))[1],
-			      ((const u8_t*) (&t->dest))[2],
-			      ((const u8_t*) (&t->dest))[3]));
-
-     LWIP_DEBUGF(NAPT_DEBUG, (" %5"U16_F" | %5"U16_F" | %5"U16_F" | %5"U16_F" |\n",
-			      lwip_htons(t->sport),
-			      lwip_htons(t->dport),
-			      lwip_htons(t->msport),
-			      lwip_htons(t->mdport)));
+     p = t->proto;
+     DPRINTF(("| %5"U16_F" | %5"U16_F" | %c%c%c%c%c%c%c | %8"U32_F" |\n",
+              lwip_ntohs(t->msport),
+              lwip_ntohs(t->mdport),
+              (p == IP_PROTO_TCP ? 'T' : (p == IP_PROTO_UDP ? 'U' : (p == IP_PROTO_ICMP ? 'I' : '?'))),
+              (t->fin1 ? 'f' : '.'),
+              (t->fin2 ? 'F' : '.'),
+              (t->finack1 ? 'a' : '.'),
+              (t->finack2 ? 'A' : '.'),
+              (t->synack ? 'S' : '.'),
+              (t->rst ? 'R' : '.'),
+              now - t->last));
 
   }
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
 }
 #endif /* NAPT_DEBUG */
 
@@ -143,10 +168,14 @@ napt_debug_print(void)
 static void
 ip_napt_deinit(void)
 {
+  napt_list = NO_IDX;
+  napt_stats.max_entries = 0;
+  ip_portmap_max = 0;
   mem_free(ip_napt_table);
+  ip_napt_table = NULL;
   mem_free(ip_portmap_table);
   ip_portmap_table = NULL;
-  ip_napt_table = NULL;
+  sys_untimeout(ip_napt_tmr, NULL);
 }
 
 /**
@@ -161,16 +190,18 @@ ip_napt_init(uint16_t max_nat, uint8_t max_portmap)
   u16_t i;
 
   if (ip_portmap_table == NULL && ip_napt_table == NULL) {
-    ip_napt_max = max_nat;
-    ip_portmap_max = max_portmap;
-
-    ip_napt_table = (struct napt_table*)mem_calloc(ip_napt_max, sizeof(struct napt_table[1]));
-    ip_portmap_table = (struct portmap_table*)mem_calloc(ip_portmap_max, sizeof(struct portmap_table[1]));
+    ip_napt_table = (struct ip_napt_entry *) mem_calloc(max_nat, sizeof(*ip_napt_table));
+    ip_portmap_table = (struct ip_portmap_entry *) mem_calloc(max_portmap, sizeof(*ip_portmap_table));
     assert(ip_portmap_table != NULL && ip_napt_table != NULL);
 
-    for (i = 0; i < ip_napt_max - 1; i++)
+    for (i = 0; i < max_nat - 1; i++)
       ip_napt_table[i].next = i + 1;
     ip_napt_table[i].next = NO_IDX;
+
+    napt_stats.max_entries = max_nat;
+    ip_portmap_max = max_portmap;
+
+    sys_timeout(NAPT_TMR_INTERVAL, ip_napt_tmr, NULL);
   }
 }
 
@@ -180,21 +211,19 @@ ip_napt_enable(u32_t addr, int enable)
   struct netif *netif;
   int napt_in_any_netif = 0;
   for (netif = netif_list; netif; netif = netif->next) {
-    if (netif->napt)
+    if (netif_is_up(netif) && !ip_addr_isany(&netif->ip_addr) && (ip_2_ip4(&netif->ip_addr)->addr) == addr) {
+      netif->napt = enable;
+    }
+    if (netif->napt) {
       napt_in_any_netif = 1;
-    if (netif_is_up(netif) && !ip_addr_isany(&netif->ip_addr) && (ip_2_ip4(&netif->ip_addr)->addr) == addr && enable) {
-      netif->napt = 1;
-      ip_napt_init(IP_NAPT_MAX, IP_PORTMAP_MAX);
-      LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d on %d\n", netif->napt, netif->num));
-      break;
     }
   }
-  if (!enable && !napt_in_any_netif) {
-    for (netif = netif_list; netif; netif = netif->next)
-      netif->napt = 0;
+  if (napt_in_any_netif) {
+    ip_napt_init(IP_NAPT_MAX, IP_PORTMAP_MAX);
+  } else {
     ip_napt_deinit();
-    LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d\n", enable));
   }
+  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d\n", enable));
 }
 
 void
@@ -208,7 +237,6 @@ ip_napt_enable_no(u8_t number, int enable)
         ip_napt_init(IP_NAPT_MAX, IP_PORTMAP_MAX);
       else
         ip_napt_deinit();
-
       LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d on %d\n", netif->napt, netif->num));
       break;
     }
@@ -244,9 +272,40 @@ checksumadjust(u8_t *chksum, u8_t *optr, int olen, u8_t *nptr, int nlen)
   chksum[0]=x/256; chksum[1]=x & 0xFFU;
 }
 
+
+static void
+ip_napt_send_rst(u32_t src_be, u16_t sport_be, u32_t dst_be, u16_t dport_be, u32_t seqno_le, u32_t ackno_le)
+{
+  struct pbuf *p = pbuf_alloc(PBUF_IP, TCP_HLEN, PBUF_RAM);
+  struct tcp_hdr *tcphdr;
+  struct netif *netif;
+  ip_addr_t src, dst;
+  if (p == NULL) return;
+  tcphdr = (struct tcp_hdr *)p->payload;
+  tcphdr->src = sport_be;
+  tcphdr->dest = dport_be;
+  tcphdr->seqno = lwip_htonl(seqno_le);
+  tcphdr->ackno = lwip_htonl(ackno_le);
+  TCPH_HDRLEN_FLAGS_SET(tcphdr, 5, (TCP_RST | TCP_ACK));
+  tcphdr->wnd = lwip_htons(512);
+  tcphdr->urgp = 0;
+  tcphdr->chksum = 0;
+  ip_addr_set_ip4_u32_val(src, src_be);
+  ip_addr_set_ip4_u32_val(dst, dst_be);
+  tcphdr->chksum = ip_chksum_pseudo(p, IP_PROTO_TCP, p->tot_len, &src, &dst);
+  netif = ip4_route(ip_2_ip4(&dst));
+  if (netif != NULL) {
+    err_t res = ip4_output_if(p, ip_2_ip4(&src), ip_2_ip4(&dst), ICMP_TTL, 0, IP_PROTO_TCP, netif);
+    LWIP_DEBUGF(NAPT_DEBUG, ("SEND RST to %#x:%u from %#x:%u seq %u ack %u res %d\n",
+        lwip_ntohl(src_be), lwip_ntohs(sport_be), lwip_ntohl(dst_be), lwip_ntohs(dport_be),
+        seqno_le, ackno_le, res));
+  }
+  pbuf_free(p);
+}
+
 /* t must be indexed by napt_free */
 static void
-ip_napt_insert(struct napt_table *t)
+ip_napt_insert(struct ip_napt_entry *t)
 {
   u16_t ti = t - ip_napt_table;
   assert(ti == napt_free);
@@ -261,21 +320,22 @@ ip_napt_insert(struct napt_table *t)
 
 #if LWIP_TCP
   if (t->proto == IP_PROTO_TCP)
-    nr_active_napt_tcp++;
+    napt_stats.nr_active_tcp++;
 #endif
 #if LWIP_UDP
   if (t->proto == IP_PROTO_UDP)
-    nr_active_napt_udp++;
+    napt_stats.nr_active_udp++;
 #endif
 #if LWIP_ICMP
   if (t->proto == IP_PROTO_ICMP)
-    nr_active_napt_icmp++;
+    napt_stats.nr_active_icmp++;
 #endif
-  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_insert(): TCP=%d, UDP=%d, ICMP=%d\n", nr_active_napt_tcp, nr_active_napt_udp, nr_active_napt_icmp));
+  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_insert(): TCP=%d, UDP=%d, ICMP=%d\n",
+                           napt_stats.nr_active_tcp, napt_stats.nr_active_udp, napt_stats.nr_active_icmp));
 }
 
 static void
-ip_napt_free(struct napt_table *t)
+ip_napt_free(struct ip_napt_entry *t)
 {
   u16_t ti = t - ip_napt_table;
   if (ti == napt_list)
@@ -292,20 +352,26 @@ ip_napt_free(struct napt_table *t)
 
 #if LWIP_TCP
   if (t->proto == IP_PROTO_TCP)
-    nr_active_napt_tcp--;
+    napt_stats.nr_active_tcp--;
 #endif
 #if LWIP_UDP
   if (t->proto == IP_PROTO_UDP)
-    nr_active_napt_udp--;
+    napt_stats.nr_active_udp--;
 #endif
 #if LWIP_ICMP
   if (t->proto == IP_PROTO_ICMP)
-    nr_active_napt_icmp--;
+    napt_stats.nr_active_icmp--;
 #endif
   LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_free\n"));
 #if NAPT_DEBUG
   napt_debug_print();
 #endif
+  /* Send RST to both sides to let them know connection is being evicted */
+  if (t->proto == IP_PROTO_TCP && t->synack && !(t->fin1 || t->fin2 || t-> rst)) {
+    /* Send RST both ways. */
+    ip_napt_send_rst(t->dest, t->dport, t->src, t->sport, t->dest_seqno, t->src_seqno);
+    ip_napt_send_rst(t->src, t->sport, t->dest, t->dport, t->src_seqno, t->dest_seqno);
+  }
 }
 
 #if LWIP_TCP
@@ -314,7 +380,7 @@ ip_napt_find_port(u8_t proto, u16_t port, u8_t dest)
 {
   int i, next;
   for (i = napt_list; i != NO_IDX; i = next) {
-    struct napt_table *t = &ip_napt_table[i];
+    struct ip_napt_entry *t = &ip_napt_table[i];
     next = t->next;
     if (dest && t->proto == proto && t->mdport == port)
       return 1;
@@ -324,7 +390,7 @@ ip_napt_find_port(u8_t proto, u16_t port, u8_t dest)
   return 0;
 }
 
-static struct portmap_table *
+static struct ip_portmap_entry *
 ip_portmap_find(u8_t proto, u16_t mport);
 
 static u8_t
@@ -358,7 +424,7 @@ static u16_t
 ip_napt_new_port(u8_t proto, u16_t port)
 {
   if (PP_NTOHS(port) >= IP_NAPT_PORT_RANGE_START && PP_NTOHS(port) <= IP_NAPT_PORT_RANGE_END)
-    if (!ip_napt_find_port(proto, port, 1) && !tcp_listening(port))
+    if (!ip_napt_find_port(proto, port,1) && !tcp_listening(port))
       return port;
   for (;;) {
     port = PP_HTONS(IP_NAPT_PORT_RANGE_START +
@@ -378,20 +444,20 @@ ip_napt_new_port(u8_t proto, u16_t port)
   }
 }
 
-static struct napt_table*
+static struct ip_napt_entry*
 ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
 {
   u16_t i, next;
   u32_t now;
-  struct napt_table *t;
+  struct ip_napt_entry *t;
 
   LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_find\n"));
   LWIP_DEBUGF(NAPT_DEBUG, ("looking up in table %s: %"U16_F".%"U16_F".%"U16_F".%"U16_F", port: %u, mport: %u\n",
-			   (dest ? "dest" : "src"),
-			   ((const u8_t*) (&addr))[0], ((const u8_t*) (&addr))[1],
-			   ((const u8_t*) (&addr))[2], ((const u8_t*) (&addr))[3],
-			   PP_HTONS(port),
-			   PP_HTONS(mport)));
+                           (dest ? "dest" : "src"),
+                           ((const u8_t*) (&addr))[0], ((const u8_t*) (&addr))[1],
+                           ((const u8_t*) (&addr))[2], ((const u8_t*) (&addr))[3],
+                           PP_HTONS(port),
+                           PP_HTONS(mport)));
 #if NAPT_DEBUG
   napt_debug_print();
 #endif
@@ -400,35 +466,12 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
   for (i = napt_list; i != NO_IDX; i = next) {
     t = NT(i);
     next = t->next;
-#if LWIP_TCP
-    if (t->proto == IP_PROTO_TCP &&
-        ((((t->finack1 && t->finack2) || !t->synack) &&
-          now - t->last > IP_NAPT_TIMEOUT_MS_TCP_DISCON) ||
-         now - t->last > IP_NAPT_TIMEOUT_MS_TCP)) {
-      ip_napt_free(t);
-      continue;
-    }
-#endif
-#if LWIP_UDP
-    if (t->proto == IP_PROTO_UDP && now - t->last > IP_NAPT_TIMEOUT_MS_UDP) {
-      ip_napt_free(t);
-      continue;
-    }
-#endif
-#if LWIP_ICMP
-    if (t->proto == IP_PROTO_ICMP && now - t->last > IP_NAPT_TIMEOUT_MS_ICMP) {
-      ip_napt_free(t);
-      continue;
-    }
-#endif
-    if (dest == 0 && t->proto == proto && t->src == addr && t->sport == port
-        && t->msport == mport) {
+    if (!dest && t->proto == proto && t->src == addr && t->sport == port && t->msport == mport) {
       t->last = now;
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
       return t;
     }
-    if (dest == 1 && t->proto == proto && t->dest == addr && t->dport == port
-        && t->mdport == mport) {
+    if (dest && t->proto == proto && t->dest == addr && t->dport == port && t->mdport == mport) {
       t->last = now;
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
       return t;
@@ -440,9 +483,9 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
 }
 
 static u16_t
-ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u16_t msport)
+ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u16_t msport, u32_t seqno)
 {
-  struct napt_table *t = ip_napt_find(proto, src, sport, msport, 0);
+  struct ip_napt_entry *t = ip_napt_find(proto, src, sport, msport, 0);
   if (t) {
     t->last = sys_now();
     t->dest = dest;
@@ -459,6 +502,10 @@ ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u16_t m
     return t->mdport;
   }
   t = NT(napt_free);
+  if (!t) {
+    ip_napt_gc(sys_now(), true /* make_room */);
+    t = NT(napt_free);
+  }
   if (t) {
     u16_t mport = sport;
 #if LWIP_TCP
@@ -478,6 +525,8 @@ ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u16_t m
     t->mdport = mport;
     t->proto = proto;
     t->fin1 = t->fin2 = t->finack1 = t->finack2 = t->synack = t->rst = 0;
+    t->src_seqno = ntohl(seqno);
+    t->dest_seqno = 0;
     ip_napt_insert(t);
 
     LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_add\n"));
@@ -499,7 +548,7 @@ ip_portmap_add(u8_t proto, u32_t maddr, u16_t mport, u32_t daddr, u16_t dport)
   dport = PP_HTONS(dport);
 
   for (i = 0; i < ip_portmap_max; i++) {
-    struct portmap_table *p = &ip_portmap_table[i];
+    struct ip_portmap_entry *p = &ip_portmap_table[i];
     if (p->valid && p->proto == proto && p->mport == mport) {
       p->dport = dport;
       p->daddr = daddr;
@@ -516,12 +565,12 @@ ip_portmap_add(u8_t proto, u32_t maddr, u16_t mport, u32_t daddr, u16_t dport)
   return 0;
 }
 
-static struct portmap_table *
+static struct ip_portmap_entry *
 ip_portmap_find(u8_t proto, u16_t mport)
 {
   int i;
   for (i = 0; i < ip_portmap_max; i++) {
-    struct portmap_table *p = &ip_portmap_table[i];
+    struct ip_portmap_entry *p = &ip_portmap_table[i];
     if (!p->valid)
       return 0;
     if (p->proto == proto && p->mport == mport)
@@ -530,12 +579,12 @@ ip_portmap_find(u8_t proto, u16_t mport)
   return NULL;
 }
 
-static struct portmap_table *
+static struct ip_portmap_entry *
 ip_portmap_find_dest(u8_t proto, u16_t dport, u32_t daddr)
 {
   int i;
   for (i = 0; i < ip_portmap_max; i++) {
-    struct portmap_table *p = &ip_portmap_table[i];
+    struct ip_portmap_entry *p = &ip_portmap_table[i];
     if (!p->valid)
       return 0;
     if (p->proto == proto && p->dport == dport && p->daddr == daddr)
@@ -545,10 +594,22 @@ ip_portmap_find_dest(u8_t proto, u16_t dport, u32_t daddr)
 }
 
 u8_t
+ip_portmap_get(u8_t proto, u16_t mport, u32_t *maddr, u32_t *daddr, u16_t *dport)
+{
+  struct ip_portmap_entry *m = ip_portmap_find(proto, PP_HTONS(mport));
+  if (!m)
+    return 0;
+  *maddr = m->maddr;
+  *daddr = m->daddr;
+  *dport = PP_NTOHS(m->dport);
+  return 1;
+}
+
+u8_t
 ip_portmap_remove(u8_t proto, u16_t mport)
 {
-  struct portmap_table *last = &ip_portmap_table[ip_portmap_max - 1];
-  struct portmap_table *m = ip_portmap_find(proto, PP_HTONS(mport));
+  struct ip_portmap_entry *last = &ip_portmap_table[ip_portmap_max - 1];
+  struct ip_portmap_entry *m = ip_portmap_find(proto, PP_HTONS(mport));
   if (!m)
     return 0;
   for (; m != last; m++)
@@ -610,11 +671,10 @@ ip_napt_modify_addr(struct ip_hdr *iphdr, ip4_addr_p_t *field, u32_t newval)
 void
 ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr)
 {
+  struct ip_portmap_entry *m;
+  struct ip_napt_entry *t;
+  if (napt_stats.max_entries == 0) return;
 
-  struct portmap_table *m;
-  struct napt_table *t;
-
-  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_recv: start\n"));
 #if LWIP_ICMP
   /* NAPT for ICMP Echo Request using identifier */
   if (IPH_PROTO(iphdr) == IP_PROTO_ICMP) {
@@ -633,19 +693,20 @@ ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr)
 
 #if LWIP_TCP
   if (IPH_PROTO(iphdr) == IP_PROTO_TCP) {
+    uint32_t seqno, dest_seqno;
     struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
 
 
     LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_recv\n"));
     LWIP_DEBUGF(NAPT_DEBUG, ("src: %"U16_F".%"U16_F".%"U16_F".%"U16_F", dest: %"U16_F".%"U16_F".%"U16_F".%"U16_F", \n",
-			     ip4_addr1_16(&iphdr->src), ip4_addr2_16(&iphdr->src),
-			     ip4_addr3_16(&iphdr->src), ip4_addr4_16(&iphdr->src),
-			     ip4_addr1_16(&iphdr->dest), ip4_addr2_16(&iphdr->dest),
-			     ip4_addr3_16(&iphdr->dest), ip4_addr4_16(&iphdr->dest)));
+                             ip4_addr1_16(&iphdr->src), ip4_addr2_16(&iphdr->src),
+                             ip4_addr3_16(&iphdr->src), ip4_addr4_16(&iphdr->src),
+                             ip4_addr1_16(&iphdr->dest), ip4_addr2_16(&iphdr->dest),
+                             ip4_addr3_16(&iphdr->dest), ip4_addr4_16(&iphdr->dest)));
 
     LWIP_DEBUGF(NAPT_DEBUG, ("sport %u, dport: %u\n",
-			     lwip_htons(tcphdr->src),
-			     lwip_htons(tcphdr->dest)));
+                             lwip_htons(tcphdr->src),
+                             lwip_htons(tcphdr->dest)));
 
     m = ip_portmap_find(IP_PROTO_TCP, tcphdr->dest);
     if (m) {
@@ -657,23 +718,28 @@ ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr)
       return;
     }
     t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 1);
-      if (!t)
-        return; /* Unknown TCP session; do nothing */
+    if (!t)
+      return; /* Unknown TCP session; do nothing */
 
-      if (t->sport != tcphdr->dest)
-        ip_napt_modify_port_tcp(tcphdr, 1, t->sport);
-      ip_napt_modify_addr_tcp(tcphdr, &iphdr->dest, t->src);
-      ip_napt_modify_addr(iphdr, &iphdr->dest, t->src);
+    if (t->sport != tcphdr->dest)
+      ip_napt_modify_port_tcp(tcphdr, 1, t->sport);
+    ip_napt_modify_addr_tcp(tcphdr, &iphdr->dest, t->src);
+    ip_napt_modify_addr(iphdr, &iphdr->dest, t->src);
 
-      if ((TCPH_FLAGS(tcphdr) & (TCP_SYN|TCP_ACK)) == (TCP_SYN|TCP_ACK))
-        t->synack = 1;
-      if ((TCPH_FLAGS(tcphdr) & TCP_FIN))
-        t->fin1 = 1;
-      if (t->fin2 && (TCPH_FLAGS(tcphdr) & TCP_ACK))
-        t->finack2 = 1; /* FIXME: Currently ignoring ACK seq... */
-      if (TCPH_FLAGS(tcphdr) & TCP_RST)
-        t->rst = 1;
-      return;
+    if ((TCPH_FLAGS(tcphdr) & (TCP_SYN|TCP_ACK)) == (TCP_SYN|TCP_ACK))
+      t->synack = 1;
+    if ((TCPH_FLAGS(tcphdr) & TCP_FIN))
+      t->fin1 = 1;
+    if (t->fin2 && (TCPH_FLAGS(tcphdr) & TCP_ACK))
+      t->finack2 = 1; /* FIXME: Currently ignoring ACK seq... */
+    if (TCPH_FLAGS(tcphdr) & TCP_RST)
+      t->rst = 1;
+    seqno = ntohl(tcphdr->seqno);
+    dest_seqno = t->dest_seqno;
+    if (seqno >= dest_seqno || WRAPPED_AROUND(seqno, dest_seqno)) {
+      t->dest_seqno = seqno + (p->tot_len - IPH_HL(iphdr) * 4 - TCPH_HDRLEN_BYTES(tcphdr));
+    }
+    return;
   }
 #endif /* LWIP_TCP */
 
@@ -705,13 +771,8 @@ ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr)
 err_t
 ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct netif *outp)
 {
-  LWIP_DEBUGF(IP_DEBUG, ("ip_napt_forward: start\n"));
-
-  if (!inp->napt) {
-    LWIP_DEBUGF(IP_DEBUG, ("ip_napt_forward: inp->napt is off, %d for netif %d\n", 
-      inp->napt, inp->num));
+  if (!inp->napt)
     return ERR_OK;
-  }
 
 #if LWIP_ICMP
   /* NAPT for ICMP Echo Request using identifier */
@@ -719,7 +780,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     struct icmp_echo_hdr *iecho = (struct icmp_echo_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
     if (iecho->type == ICMP_ECHO) {
       /* register src addr and iecho->id and dest info */
-      ip_napt_add(IP_PROTO_ICMP, iphdr->src.addr, iecho->id, iphdr->dest.addr, iecho->id, 0);
+      ip_napt_add(IP_PROTO_ICMP, iphdr->src.addr, iecho->id, iphdr->dest.addr, iecho->id, 0, 0);
 
       ip_napt_modify_addr(iphdr, &iphdr->src, ip_2_ip4(&outp->ip_addr)->addr);
     }
@@ -733,7 +794,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
     u16_t mport;
 
-    struct portmap_table *m = ip_portmap_find_dest(IP_PROTO_TCP, tcphdr->src, iphdr->src.addr);
+    struct ip_portmap_entry *m = ip_portmap_find_dest(IP_PROTO_TCP, tcphdr->src, iphdr->src.addr);
     if (m) {
       /* packet from port-mapped dest addr/port: rewrite source to this node */
       if (m->mport != tcphdr->src)
@@ -746,24 +807,34 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
         PP_NTOHS(tcphdr->src) >= 1024) {
       /* Register new TCP session to NAPT */
       mport = ip_napt_add(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src,
-                          iphdr->dest.addr, tcphdr->dest, tcphdr->dest);
-      if (mport == 0)
+                          iphdr->dest.addr, tcphdr->dest, tcphdr->dest, tcphdr->seqno);
+      if (mport == 0) {
+#if LWIP_ICMP
+        icmp_dest_unreach(p, ICMP_DUR_PORT);
+#endif
         return ERR_RTE; /* routing err if add entry failed */
+      }
     } else {
-      struct napt_table *t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 0);
+      uint32_t seqno, src_seqno;
+      struct ip_napt_entry *t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 0);
       if (!t || t->dest != iphdr->dest.addr || t->dport != tcphdr->dest) {
 #if LWIP_ICMP
-      icmp_dest_unreach(p, ICMP_DUR_PORT);
+        icmp_dest_unreach(p, ICMP_DUR_PORT);
 #endif
-      return ERR_RTE; /* Drop unknown TCP session */
-    }
-    mport = t->mdport;
-    if ((TCPH_FLAGS(tcphdr) & TCP_FIN))
+        return ERR_RTE; /* Drop unknown TCP session */
+      }
+      mport = t->mdport;
+      if ((TCPH_FLAGS(tcphdr) & TCP_FIN))
         t->fin2 = 1;
-    if (t->fin1 && (TCPH_FLAGS(tcphdr) & TCP_ACK))
+      if (t->fin1 && (TCPH_FLAGS(tcphdr) & TCP_ACK))
         t->finack1 = 1; /* FIXME: Currently ignoring ACK seq... */
-    if (TCPH_FLAGS(tcphdr) & TCP_RST)
+      if (TCPH_FLAGS(tcphdr) & TCP_RST)
         t->rst = 1;
+      seqno = ntohl(tcphdr->seqno);
+      src_seqno = t->src_seqno;
+      if (seqno >= t->src_seqno || WRAPPED_AROUND(seqno, src_seqno)) {
+        t->src_seqno = seqno + (p->tot_len - IPH_HL(iphdr) * 4 - TCPH_HDRLEN_BYTES(tcphdr));
+      }
     }
 
     if (mport != tcphdr->src)
@@ -780,7 +851,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     struct udp_hdr *udphdr = (struct udp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
     u16_t mport;
 
-    struct portmap_table *m = ip_portmap_find_dest(IP_PROTO_UDP, udphdr->src, iphdr->src.addr);
+    struct ip_portmap_entry *m = ip_portmap_find_dest(IP_PROTO_UDP, udphdr->src, iphdr->src.addr);
     if (m) {
       /* packet from port-mapped dest addr/port: rewrite source to this node */
       if (m->mport != udphdr->src)
@@ -793,11 +864,11 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     if (PP_NTOHS(udphdr->src) >= 1024) {
       /* Register new UDP session */
       mport = ip_napt_add(IP_PROTO_UDP, iphdr->src.addr, udphdr->src,
-                          iphdr->dest.addr, udphdr->dest, udphdr->dest);
+                          iphdr->dest.addr, udphdr->dest, udphdr->dest, 0);
       if (mport == 0)
         return ERR_RTE; /* routing err if add entry failed */
     } else {
-      struct napt_table *t = ip_napt_find(IP_PROTO_UDP, iphdr->src.addr, udphdr->src, udphdr->dest, 0);
+      struct ip_napt_entry *t = ip_napt_find(IP_PROTO_UDP, iphdr->src.addr, udphdr->src, 0, 0);
       if (!t || t->dest != iphdr->dest.addr || t->dport != udphdr->dest) {
 #if LWIP_ICMP
         icmp_dest_unreach(p, ICMP_DUR_PORT);
@@ -827,8 +898,8 @@ ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
   if (IPH_PROTO(iphdr) == IP_PROTO_TCP) {
     struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
 
-    struct napt_table *t;
-    struct portmap_table *m;
+    struct ip_napt_entry *t;
+    struct ip_portmap_entry *m;
     
     t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 1);
     if (t) {
@@ -858,7 +929,7 @@ ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
     if (m) {
       /* packet from port-mapped dest addr/port: rewrite source to this node */
       u16_t mport = ip_napt_add(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src,
-                          m->daddr, m->dport, tcphdr->dest);
+                          m->daddr, m->dport, tcphdr->dest, 0);
       ip_napt_modify_port_tcp(tcphdr, 0, mport);
       ip_napt_modify_addr_tcp(tcphdr, &iphdr->src, m->maddr);
       ip_napt_modify_addr(iphdr, &iphdr->src, m->maddr);
@@ -875,8 +946,8 @@ ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
   if (IPH_PROTO(iphdr) == IP_PROTO_UDP) {
     struct udp_hdr *udphdr = (struct udp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
 
-    struct napt_table *t;
-    struct portmap_table *m;
+    struct ip_napt_entry *t;
+    struct ip_portmap_entry *m;
     
     t = ip_napt_find(IP_PROTO_UDP, iphdr->src.addr, udphdr->src, udphdr->dest, 1);
     if (t) {
@@ -906,7 +977,7 @@ ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
     if (m) {
       /* packet from port-mapped dest addr/port: rewrite source to this node */
       u16_t mport = ip_napt_add(IP_PROTO_UDP, iphdr->src.addr, udphdr->src,
-                          m->daddr, m->dport, udphdr->dest);
+                          m->daddr, m->dport, udphdr->dest, 0);
       ip_napt_modify_port_udp(udphdr, 0, mport);
       ip_napt_modify_addr_udp(udphdr, &iphdr->src, m->maddr);
       ip_napt_modify_addr(iphdr, &iphdr->src, m->maddr);
@@ -922,6 +993,99 @@ ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
   return ERR_RTE;
 }
 
-#endif /* IP_NAPT */
-#endif /* LWIP_IPV4 */
-#endif /* ESP_LWIP */
+static void
+ip_napt_gc(uint32_t now, bool force)
+{
+  u16_t i, next, oldest = NO_IDX;
+  u32_t age = 0, oldest_age = 0;
+  int checked = 0, evicted = 0, forced = 0;
+  for (i = napt_list; i != NO_IDX; i = next) {
+    struct ip_napt_entry *t = &ip_napt_table[i];
+    checked++;
+    next = t->next;
+    age = now - t->last;
+    if (age > oldest_age) {
+      oldest = i;
+      oldest_age = age;
+    }
+#if LWIP_TCP
+    if (t->proto == IP_PROTO_TCP) {
+      if (age > IP_NAPT_TIMEOUT_MS_TCP_DISCON) {
+        if ((t->finack1 || t->finack2 || !t->synack || t->rst) ||
+            age > IP_NAPT_TIMEOUT_MS_TCP) {
+          ip_napt_free(t);
+          evicted++;
+          if (force) break;
+        }
+      }
+      continue;
+    }
+#endif
+#if LWIP_UDP
+    if (t->proto == IP_PROTO_UDP) {
+      if (age > IP_NAPT_TIMEOUT_MS_UDP) {
+        ip_napt_free(t);
+        evicted++;
+        if (force) break;
+      }
+      continue;
+    }
+#endif
+#if LWIP_ICMP
+    if (t->proto == IP_PROTO_ICMP) {
+      if (age > IP_NAPT_TIMEOUT_MS_ICMP) {
+        ip_napt_free(t);
+        evicted++;
+        if (force) break;
+      }
+      continue;
+    }
+#endif
+  }
+  if (napt_free == NO_IDX && force && oldest != NO_IDX) {
+    ip_napt_free(&ip_napt_table[oldest]);
+    evicted++;
+    forced++;
+    napt_stats.nr_forced_evictions++;
+  }
+  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt_gc(%d): chk %d evict %d (forced %d), oldest %u\n",
+                           force, checked, evicted, forced, oldest_age));
+}
+
+static void
+ip_napt_maint(void)
+{
+  static uint32_t s_last_now = 0;
+  uint32_t now;
+  if (napt_list == NO_IDX) return;
+  now = sys_now();
+  /* Check for timestamp wraparound (happens every ~49.7 days). */
+  if (WRAPPED_AROUND(s_last_now, now)) {
+    u16_t i;
+    struct ip_napt_entry *t;
+    for (i = napt_list; i != NO_IDX; i = t->next) {
+      t = &ip_napt_table[i];
+      /* It's a very simplistic way of dealing with it
+       * but it's fine for our purposes. */
+      t->last = now;
+    }
+    /* Skip until next tick, nothing to be done here anyway. */
+    return;
+  }
+  ip_napt_gc(now, false /* make_room */);
+  s_last_now = now;
+}
+
+static void
+ip_napt_tmr(void *arg) {
+  ip_napt_maint();
+  sys_timeout(NAPT_TMR_INTERVAL, ip_napt_tmr, arg);
+}
+
+void
+ip_napt_get_stats(struct ip_napt_stats *stats)
+{
+  *stats = napt_stats;
+}
+
+#endif /* ESP_LWIP && LWIP_IPV4 && IP_NAPT */

--- a/src/core/ipv4/ip4_napt.c
+++ b/src/core/ipv4/ip4_napt.c
@@ -193,7 +193,7 @@ ip_napt_enable(u32_t addr, int enable)
     for (netif = netif_list; netif; netif = netif->next)
       netif->napt = 0;
     ip_napt_deinit();
-    LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to 0\n"));
+    LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d\n", enable));
   }
 }
 

--- a/src/core/ipv4/ip4_napt.c
+++ b/src/core/ipv4/ip4_napt.c
@@ -193,7 +193,7 @@ ip_napt_enable(u32_t addr, int enable)
     for (netif = netif_list; netif; netif = netif->next)
       netif->napt = 0;
     ip_napt_deinit();
-    LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d on %d\n", netif->napt, netif->num));
+    LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to 0\n"));
   }
 }
 

--- a/src/include/lwip/ip4_napt.h
+++ b/src/include/lwip/ip4_napt.h
@@ -60,27 +60,32 @@ extern "C" {
 #include "lwip/err.h"
 #include "lwip/ip4.h"
 
+
+#ifndef NAPT_TMR_INTERVAL
+#define NAPT_TMR_INTERVAL 2000
+#endif
+
 /**
-* NAPT for a forwarded packet. It checks whether we need NAPT and modify
-* the packet source address and port if needed.
-*
-* @param p the packet to forward (p->payload points to IP header)
-* @param iphdr the IP header of the input packet
-* @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
-*/
+ * NAPT for a forwarded packet. It checks whether we need NAPT and modify
+ * the packet source address and port if needed.
+ *
+ * @param p the packet to forward (p->payload points to IP header)
+ * @param iphdr the IP header of the input packet
+ * @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
+ */
 err_t
 ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr);
 
 /**
-* NAPT for a forwarded packet. It checks weather we need NAPT and modify
-* the packet source address and port if needed.
-*
-* @param p the packet to forward (p->payload points to IP header)
-* @param iphdr the IP header of the input packet
-* @param inp the netif on which this packet was received
-* @param outp the netif on which this packet will be sent
-* @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
-*/
+ * NAPT for a forwarded packet. It checks weather we need NAPT and modify
+ * the packet source address and port if needed.
+ *
+ * @param p the packet to forward (p->payload points to IP header)
+ * @param iphdr the IP header of the input packet
+ * @param inp the netif on which this packet was received
+ * @param outp the netif on which this packet will be sent
+ * @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
+ */
 err_t
 ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct netif *outp);
 
@@ -90,7 +95,6 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
  *
  * @param p the packet to forward (p->payload points to IP header)
  * @param iphdr the IP header of the input packet
- * @param inp the netif on which this packet was received
  */
 void
 ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr);

--- a/src/include/lwip/ip4_napt.h
+++ b/src/include/lwip/ip4_napt.h
@@ -61,16 +61,15 @@ extern "C" {
 #include "lwip/ip4.h"
 
 /**
-* NAPT for a forwarded packet. It checks weather we need NAPT and modify
+* NAPT for a forwarded packet. It checks whether we need NAPT and modify
 * the packet source address and port if needed.
 *
 * @param p the packet to forward (p->payload points to IP header)
 * @param iphdr the IP header of the input packet
-* @param inp the netif on which this packet was received
 * @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
 */
 err_t
-ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp);
+ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr);
 
 /**
 * NAPT for a forwarded packet. It checks weather we need NAPT and modify

--- a/src/include/lwip/ip4_napt.h
+++ b/src/include/lwip/ip4_napt.h
@@ -67,6 +67,18 @@ extern "C" {
 * @param p the packet to forward (p->payload points to IP header)
 * @param iphdr the IP header of the input packet
 * @param inp the netif on which this packet was received
+* @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
+*/
+err_t
+ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp);
+
+/**
+* NAPT for a forwarded packet. It checks weather we need NAPT and modify
+* the packet source address and port if needed.
+*
+* @param p the packet to forward (p->payload points to IP header)
+* @param iphdr the IP header of the input packet
+* @param inp the netif on which this packet was received
 * @param outp the netif on which this packet will be sent
 * @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
 */

--- a/test/unit/core/test_ip4_route.c
+++ b/test/unit/core/test_ip4_route.c
@@ -396,10 +396,12 @@ START_TEST(test_ip4_route_netif_napt_udp)
 
   /* cleanup */
   netif_set_down(&ap);
-  ip_napt_enable_no(ap.num, 0);
   netif_remove(&ap);
   netif_set_down(&sta);
   netif_remove(&sta);
+
+  IP4_ADDR(&addr, 10, 0, 0, 1);
+  ip_napt_enable(addr.addr, 0);
 
 #undef UDP_PORT
 }
@@ -570,6 +572,7 @@ ip4route_suite(void)
     TESTFUNC(test_ip4_route_netif_napt_tcp),
     TESTFUNC(test_ip4_route_netif_napt_tcp_PBUF_REF),
     TESTFUNC(test_ip4_route_netif_max_napt),
+    
 #endif
   };
   return create_suite("IP4_ROUTE", tests, sizeof(tests)/sizeof(testfunc), ip4route_setup, ip4route_teardown);

--- a/test/unit/core/test_ip4_route.c
+++ b/test/unit/core/test_ip4_route.c
@@ -33,6 +33,12 @@ static u32_t last_dst_addr = 0;
 static u16_t last_src_port = 0;
 
 #if IP_NAPT
+typedef enum {
+    PACKET_PBUF_RAM,
+    PACKET_PBUF_REF
+} packet_type_t;
+
+unsigned char *packet_buffer[1518];
 static int random_mock = -1;
 /* Mock the esp-random to return 0 for easier result checking */
 uint32_t esp_random(void) 
@@ -137,9 +143,11 @@ ap_tx_func(struct netif *netif, struct pbuf *p)
 #if IP_NAPT
 static struct pbuf*
 test_create_tcp_packet(u32_t src_ip4, u32_t dst_ip4,
-                   u16_t src_port, u16_t dst_port,
-                   u32_t seqno, u32_t ackno, u8_t headerflags, u16_t wnd)
+                   u16_t src_port, u16_t dst_port, u8_t headerflags,
+                   packet_type_t packet_type)
 {
+  u32_t seqno = 0, ackno = 0;
+  u16_t wnd = 0;
   struct pbuf *p, *q;
   ip_addr_t src_ip;
   ip_addr_t dst_ip;
@@ -150,7 +158,12 @@ test_create_tcp_packet(u32_t src_ip4, u32_t dst_ip4,
   src_ip.u_addr.ip4.addr = src_ip4;
   dst_ip.u_addr.ip4.addr = dst_ip4;
 
-  p = pbuf_alloc(PBUF_RAW, pbuf_len, PBUF_POOL);
+  if (packet_type == PACKET_PBUF_RAM) {
+      p = pbuf_alloc(PBUF_RAW, pbuf_len, PBUF_RAM);
+  } else {
+      p = pbuf_alloc(PBUF_RAW, pbuf_len, PBUF_REF);
+      p->payload = packet_buffer;
+  }
   EXPECT_RETNULL(p != NULL);
   /* first pbuf must be big enough to hold the headers */
   EXPECT_RETNULL(p->len >= (sizeof(struct ip_hdr) + sizeof(struct tcp_hdr)));
@@ -170,10 +183,8 @@ test_create_tcp_packet(u32_t src_ip4, u32_t dst_ip4,
   iphdr->_proto = IP_PROTO_TCP;
   IPH_CHKSUM_SET(iphdr, inet_chksum(iphdr, IP_HLEN));
 
-  /* let p point to TCP header */
-  pbuf_header(p, -(s16_t)sizeof(struct ip_hdr));
-
-  tcphdr = (struct tcp_hdr*)p->payload;
+  /* let tcphdr point to TCP header */
+  tcphdr = (struct tcp_hdr*)((char*)p->payload + sizeof(struct ip_hdr));
   tcphdr->src   = htons(src_port);
   tcphdr->dest  = htons(dst_port);
   tcphdr->seqno = htonl(seqno);
@@ -185,8 +196,6 @@ test_create_tcp_packet(u32_t src_ip4, u32_t dst_ip4,
   /* calculate checksum */
   tcphdr->chksum = ip_chksum_pseudo(p,
           IP_PROTO_TCP, p->tot_len, &src_ip, &dst_ip);
-
-  pbuf_header(p, sizeof(struct ip_hdr));
 
   return p;
 }
@@ -387,25 +396,21 @@ START_TEST(test_ip4_route_netif_napt_udp)
 
   /* cleanup */
   netif_set_down(&ap);
+  ip_napt_enable_no(ap.num, 0);
   netif_remove(&ap);
   netif_set_down(&sta);
   netif_remove(&sta);
-
-  IP4_ADDR(&addr, 10, 0, 0, 1);
-  ip_napt_enable(addr.addr, 0);
 
 #undef UDP_PORT
 }
 END_TEST
 
-START_TEST(test_ip4_route_netif_napt_tcp)
+static void test_ip4_route_netif_napt_tcp_with_params(u16_t tcp_port, packet_type_t packet_type)
 {
-#define TCP_PORT 2222
   ip4_addr_t addr, src_addr, sta_addr;
   ip4_addr_t netmask;
   ip4_addr_t gw;
   struct pbuf *p;
-  LWIP_UNUSED_ARG(_i);
 
   /* setup station */
   IP4_ADDR(&sta_addr, 1, 2, 4, 4);
@@ -425,8 +430,8 @@ START_TEST(test_ip4_route_netif_napt_tcp)
   /* create packet and send it to the AP */
   IP4_ADDR(&addr, 1, 2, 4, 100);
   IP4_ADDR(&src_addr, 10, 0, 0, 2);
-  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT, TCP_PORT, 0, 0, TCP_SYN, 0);
- 
+  p = test_create_tcp_packet(src_addr.addr, addr.addr, tcp_port, tcp_port, TCP_SYN, packet_type);
+
   random_mock = 2;
   send_to_netif(&ap, p);
 
@@ -436,12 +441,12 @@ START_TEST(test_ip4_route_netif_napt_tcp)
   fail_unless(ap_cnt == 0);
   fail_unless(sta_cnt == 1);
 
-  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT, IP_NAPT_PORT_RANGE_START+random_mock, 0, 0, TCP_SYN|TCP_ACK, 0);
+  p = test_create_tcp_packet(addr.addr, sta_addr.addr, tcp_port, IP_NAPT_PORT_RANGE_START+random_mock, TCP_SYN|TCP_ACK, packet_type);
   send_to_netif(&sta, p);
   fail_unless(ap_cnt == 1);
   fail_unless(sta_cnt == 1);
   /* expect to see a random port and translated source address to be station address */
-  fail_unless(last_src_port == lwip_ntohs(TCP_PORT));
+  fail_unless(last_src_port == lwip_ntohs(tcp_port));
   fail_unless(last_dst_addr == src_addr.addr);
 
   /* cleanup */
@@ -450,18 +455,29 @@ START_TEST(test_ip4_route_netif_napt_tcp)
   netif_remove(&ap);
   netif_set_down(&sta);
   netif_remove(&sta);
+}
 
-#undef TCP_PORT
+START_TEST(test_ip4_route_netif_napt_tcp)
+{
+    test_ip4_route_netif_napt_tcp_with_params(2222, PACKET_PBUF_RAM);
+}
+END_TEST
+
+START_TEST(test_ip4_route_netif_napt_tcp_PBUF_REF)
+{
+    test_ip4_route_netif_napt_tcp_with_params(4567, PACKET_PBUF_REF);
 }
 END_TEST
 
 START_TEST(test_ip4_route_netif_max_napt)
 {
 #define TCP_PORT 2222
+  packet_type_t packet_type = PACKET_PBUF_RAM;
   ip4_addr_t addr, src_addr, sta_addr;
   ip4_addr_t netmask;
   ip4_addr_t gw;
   struct pbuf *p;
+  int i;
   LWIP_UNUSED_ARG(_i);
 
   /* setup station */
@@ -482,9 +498,9 @@ START_TEST(test_ip4_route_netif_max_napt)
   /* create packet and send it to the AP */
   IP4_ADDR(&addr, 1, 2, 4, 100);
   IP4_ADDR(&src_addr, 10, 0, 0, 2);
-  for (int i=0; i<IP_NAPT_MAX*2; ++i) {
+  for (i=0; i<IP_NAPT_MAX*2; ++i) {
     random_mock = i;
-    p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + i, TCP_PORT + i, 0, 0, TCP_SYN, 0);
+    p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + i, TCP_PORT + i, TCP_SYN, packet_type);
     send_to_netif(&ap, p);
 
     if (i<IP_NAPT_MAX) {
@@ -492,7 +508,7 @@ START_TEST(test_ip4_route_netif_max_napt)
       fail_unless(last_src_port == lwip_ntohs(IP_NAPT_PORT_RANGE_START+random_mock));
       fail_unless(last_src_addr == sta_addr.addr);
       fail_unless(sta_cnt == 1+i);
-      p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+i, IP_NAPT_PORT_RANGE_START+random_mock, 0, 0, TCP_SYN | TCP_ACK, 0);
+      p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+i, IP_NAPT_PORT_RANGE_START+random_mock, TCP_SYN | TCP_ACK, packet_type);
       send_to_netif(&sta, p);
 
     } else {
@@ -503,26 +519,26 @@ START_TEST(test_ip4_route_netif_max_napt)
 
   /* moves time forward to test releasing: */
   lwip_sys_now += IP_NAPT_TIMEOUT_MS_TCP_DISCON + 1;
-  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT, IP_NAPT_PORT_RANGE_START+0, 0, 0, TCP_PSH, 0);
+  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT, IP_NAPT_PORT_RANGE_START+0, TCP_PSH, packet_type);
   send_to_netif(&sta, p);
-  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + IP_NAPT_MAX*2, TCP_PORT + IP_NAPT_MAX*2, 0, 0, TCP_PSH | TCP_ACK, 0);
+  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + IP_NAPT_MAX*2, TCP_PORT + IP_NAPT_MAX*2, TCP_PSH | TCP_ACK, packet_type);
   sta_cnt = 0;
   send_to_netif(&ap, p);
   /* should not be released yet, since all the TCP connections are active */
   fail_unless(sta_cnt == 0);  /* expect no packet forwarded */
 
   /* FIN the first connection so it could be released */
-  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+0, IP_NAPT_PORT_RANGE_START+0, 0, 0, TCP_FIN, 0);
+  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+0, IP_NAPT_PORT_RANGE_START+0, TCP_FIN, packet_type);
   send_to_netif(&sta, p);
-  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT+0, TCP_PORT + 0, 0, 0, TCP_FIN | TCP_ACK, 0);
+  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT+0, TCP_PORT + 0, TCP_FIN | TCP_ACK, packet_type);
   send_to_netif(&ap, p);
-  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+0, IP_NAPT_PORT_RANGE_START+0, 0, 0, TCP_ACK, 0);
+  p = test_create_tcp_packet(addr.addr, sta_addr.addr, TCP_PORT+0, IP_NAPT_PORT_RANGE_START+0, TCP_ACK, packet_type);
   send_to_netif(&sta, p);
   /* moves time forward to test releasing: */
   lwip_sys_now += IP_NAPT_TIMEOUT_MS_TCP_DISCON + 1;
 
   /* now sending a new packet with max port, that should be forwarded */  
-  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + IP_NAPT_MAX*2, TCP_PORT + IP_NAPT_MAX*2, 0, 0, TCP_SYN, 0);
+  p = test_create_tcp_packet(src_addr.addr, addr.addr, TCP_PORT + IP_NAPT_MAX*2, TCP_PORT + IP_NAPT_MAX*2, TCP_SYN, packet_type);
   random_mock = 0;
   sta_cnt = 0;
   send_to_netif(&ap, p);
@@ -552,8 +568,8 @@ ip4route_suite(void)
 #if IP_NAPT
     TESTFUNC(test_ip4_route_netif_napt_udp),
     TESTFUNC(test_ip4_route_netif_napt_tcp),
+    TESTFUNC(test_ip4_route_netif_napt_tcp_PBUF_REF),
     TESTFUNC(test_ip4_route_netif_max_napt),
-    
 #endif
   };
   return create_suite("IP4_ROUTE", tests, sizeof(tests)/sizeof(testfunc), ip4route_setup, ip4route_teardown);


### PR DESCRIPTION
As currently written in ESP-IDF 4.4.0 (lwip 2.1.2), lwip cannot possibly forward back onto the same network (what I need) without errors. I will explain. If A is the source, B the port forwarder and C the destination, as currently written ip4_forward only modifies the destination in the packet. So a packet will be forwarded with source as A and destination as C. This is okay if the packet is going to a different network than the source. If the destination is on the same network (netif) as the source then when C receives the packet it will return directly to A. Then A will drop the packet because it does not have any known connections with C. A had a connection open to B, not C. (I verified this behavior with wireshark.) My update to lwip fixes this. If the packet is forwarded to the same network as the source, my update will have destination C return to B which will then return to A. All traffic is as expected, all connections are properly handled. I also updated some of the debug messages to aid in debugging this issue. 

Note that IP_FORWARD, IP_NAPT and IP_FORWARD_ALLOW_TX_ON_RX_NETIF must all be enabled in opt.h (something I had to do manually since menuconfig does not currently handle this) in order for the port forwarding functionality to work.