### PR TITLE
ip_napt_maint: Fix timestamp overflow handling (IDFGH-7201)

### DIFF
--- a/src/core/ipv4/dhcp.c
+++ b/src/core/ipv4/dhcp.c
@@ -364,7 +364,9 @@ dhcp_check(struct netif *netif)
 static void
 dhcp_handle_offer(struct netif *netif, struct dhcp_msg *msg_in)
 {
+#if ESP_DHCP && !ESP_DHCP_DISABLE_VENDOR_CLASS_IDENTIFIER
   u8_t n;
+#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_VENDOR_CLASS_IDENTIFIER */
   struct dhcp *dhcp = netif_dhcp_data(netif);
 
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp_handle_offer(netif=%p) %c%c%"U16_F"\n",

--- a/src/core/ipv4/ip4_napt.c
+++ b/src/core/ipv4/ip4_napt.c
@@ -959,15 +959,14 @@ ip_napt_maint(void)
        * but it's fine for our purposes. */
       t->last = now;
     }
-    /* Skip until next tick, nothing to be done here anyway. */
-    return;
   }
   ip_napt_gc(now, false /* make_room */);
   s_last_now = now;
 }
 
 static void
-ip_napt_tmr(void *arg) {
+ip_napt_tmr(void *arg)
+{
   ip_napt_maint();
   sys_timeout(NAPT_TMR_INTERVAL, ip_napt_tmr, arg);
 }


### PR DESCRIPTION
s_last_now was not being updated once overflow happened.