### PR TITLE
lwip with port forwarding on same netif (IDFGH-7397)

### DIFF
--- a/src/core/ipv4/ip4.c
+++ b/src/core/ipv4/ip4.c
@@ -320,6 +320,120 @@ ip4_canforward(struct pbuf *p)
   return 1;
 }
 
+#if IP_NAPT
+#if IP_FORWARD
+/**
+ * Forwards an IP packet back to the same interface it came in on if an napt or forward
+ * rule exists for it. It decrements the TTL value of the packet, adjusts the
+ * checksum and outputs the packet on the appropriate interface.
+ *
+ * @param p the packet to forward (p->payload points to IP header)
+ * @param iphdr the IP header of the input packet
+ * @param inp the netif on which this packet was received
+ * return ERR_OK if packet was forwarded
+ */
+static err_t
+ip4_forward_local(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
+{
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_forward_local: start\n"));
+
+  PERF_START;
+  LWIP_UNUSED_ARG(inp);
+
+  if (!ip4_canforward(p)) {
+    goto return_noroute;
+  }
+
+  /* RFC3927 2.7: do not forward link-local addresses */
+  if (ip4_addr_islinklocal(ip4_current_dest_addr())) {
+    LWIP_DEBUGF(IP_DEBUG, ("ip4_forward_local: not forwarding LLA %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n",
+                           ip4_addr1_16(ip4_current_dest_addr()), ip4_addr2_16(ip4_current_dest_addr()),
+                           ip4_addr3_16(ip4_current_dest_addr()), ip4_addr4_16(ip4_current_dest_addr())));
+    goto return_noroute;
+  }
+
+  /* decrement TTL */
+  IPH_TTL_SET(iphdr, IPH_TTL(iphdr) - 1);
+  /* send ICMP if TTL == 0 */
+  if (IPH_TTL(iphdr) == 0) {
+    MIB2_STATS_INC(mib2.ipinhdrerrors);
+#if LWIP_ICMP
+    /* Don't send ICMP messages in response to ICMP messages */
+    if (IPH_PROTO(iphdr) != IP_PROTO_ICMP) {
+      icmp_time_exceeded(p, ICMP_TE_TTL);
+    }
+#endif /* LWIP_ICMP */
+    return ERR_RTE;
+  }
+
+#if ESP_LWIP
+#if IP_NAPT
+  if (ip_napt_forward_local(p, iphdr) != ERR_OK)
+    return ERR_RTE;
+#endif
+#endif /* ESP_LWIP */
+
+  /* copy IP addresses to aligned ip_addr_t */
+  ip_addr_copy_from_ip4(ip_data.current_iphdr_dest, iphdr->dest);
+  ip_addr_copy_from_ip4(ip_data.current_iphdr_src, iphdr->src);
+
+  /* Incrementally update the IP checksum. */
+  if (IPH_CHKSUM(iphdr) >= PP_HTONS(0xffffU - 0x100)) {
+    IPH_CHKSUM_SET(iphdr, (u16_t)(IPH_CHKSUM(iphdr) + PP_HTONS(0x100) + 1));
+  } else {
+    IPH_CHKSUM_SET(iphdr, (u16_t)(IPH_CHKSUM(iphdr) + PP_HTONS(0x100)));
+  }
+
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_forward_local: forwarding packet from %"U16_F".%"U16_F".%"U16_F".%"U16_F" ",
+                         ip4_addr1_16(ip4_current_src_addr()), ip4_addr2_16(ip4_current_src_addr()),
+                         ip4_addr3_16(ip4_current_src_addr()), ip4_addr4_16(ip4_current_src_addr())));
+  LWIP_DEBUGF(IP_DEBUG, ("to %"U16_F".%"U16_F".%"U16_F".%"U16_F" \n",
+                         ip4_addr1_16(ip4_current_dest_addr()), ip4_addr2_16(ip4_current_dest_addr()),
+                         ip4_addr3_16(ip4_current_dest_addr()), ip4_addr4_16(ip4_current_dest_addr())));
+#if IP_DEBUG
+  if (IPH_PROTO(iphdr) == IP_PROTO_TCP) {
+    struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+    LWIP_DEBUGF(IP_DEBUG, ("        sport: %u dport: %u, netif->num %u\n", lwip_htons(tcphdr->src), lwip_htons(tcphdr->dest), inp->num));
+  } else
+  if (IPH_PROTO(iphdr) == IP_PROTO_UDP) {
+    struct udp_hdr *udphdr = (struct udp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+    LWIP_DEBUGF(IP_DEBUG, ("        sport: %u dport: %u, netif->num %u\n", lwip_htons(udphdr->src), lwip_htons(udphdr->dest), inp->num));
+  } else {
+    LWIP_DEBUGF(IP_DEBUG, ("\n"));
+  }
+#endif
+
+  IP_STATS_INC(ip.fw);
+  MIB2_STATS_INC(mib2.ipforwdatagrams);
+  IP_STATS_INC(ip.xmit);
+
+  PERF_STOP("ip4_forward_local");
+  /* don't fragment if interface has mtu set to 0 [loopif] */
+  if (inp->mtu && (p->tot_len > inp->mtu)) {
+    if ((IPH_OFFSET(iphdr) & PP_NTOHS(IP_DF)) == 0) {
+#if IP_FRAG
+      ip4_frag(p, inp, ip4_current_dest_addr());
+#else /* IP_FRAG */
+      /* @todo: send ICMP Destination Unreachable code 13 "Communication administratively prohibited"? */
+#endif /* IP_FRAG */
+    } else {
+#if LWIP_ICMP
+      /* send ICMP Destination Unreachable code 4: "Fragmentation Needed and DF Set" */
+      icmp_dest_unreach(p, ICMP_DUR_FRAG);
+#endif /* LWIP_ICMP */
+    }
+    return ERR_RTE;
+  }
+  /* transmit pbuf on inp interface */
+  inp->output(inp, p, ip4_current_dest_addr());
+  return ERR_OK;
+return_noroute:
+  MIB2_STATS_INC(mib2.ipoutnoroutes);
+  return ERR_RTE;
+}
+#endif /* FORWARD */
+#endif /* NAPT */
+
 /**
  * Forwards an IP packet. It finds an appropriate route for the
  * packet, decrements the TTL value of the packet, adjusts the
@@ -395,9 +509,21 @@ ip4_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
     IPH_CHKSUM_SET(iphdr, (u16_t)(IPH_CHKSUM(iphdr) + PP_HTONS(0x100)));
   }
 
-  LWIP_DEBUGF(IP_DEBUG, ("ip4_forward: forwarding packet to %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n",
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_forward: forwarding packet to %"U16_F".%"U16_F".%"U16_F".%"U16_F" ",
                          ip4_addr1_16(ip4_current_dest_addr()), ip4_addr2_16(ip4_current_dest_addr()),
                          ip4_addr3_16(ip4_current_dest_addr()), ip4_addr4_16(ip4_current_dest_addr())));
+#if IP_DEBUG
+  if (IPH_PROTO(iphdr) == IP_PROTO_TCP) {
+    struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+    LWIP_DEBUGF(IP_DEBUG, ("dport: %u, netif->num %u\n", lwip_htons(tcphdr->dest), netif->num));
+  } else
+  if (IPH_PROTO(iphdr) == IP_PROTO_UDP) {
+    struct udp_hdr *udphdr = (struct udp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+    LWIP_DEBUGF(IP_DEBUG, ("dport: %u, netif->num %u\n", lwip_htons(udphdr->dest), netif->num));
+  } else {
+    LWIP_DEBUGF(IP_DEBUG, ("\n"));
+  }
+#endif
 
   IP_STATS_INC(ip.fw);
   MIB2_STATS_INC(mib2.ipforwdatagrams);
@@ -448,11 +574,35 @@ return_noroute:
 static int
 ip4_input_accept(struct netif *netif)
 {
-  LWIP_DEBUGF(IP_DEBUG, ("ip_input: iphdr->dest 0x%"X32_F" netif->ip_addr 0x%"X32_F" (0x%"X32_F", 0x%"X32_F", 0x%"X32_F")\n",
-                         ip4_addr_get_u32(ip4_current_dest_addr()), ip4_addr_get_u32(netif_ip4_addr(netif)),
-                         ip4_addr_get_u32(ip4_current_dest_addr()) & ip4_addr_get_u32(netif_ip4_netmask(netif)),
-                         ip4_addr_get_u32(netif_ip4_addr(netif)) & ip4_addr_get_u32(netif_ip4_netmask(netif)),
-                         ip4_addr_get_u32(ip4_current_dest_addr()) & ~ip4_addr_get_u32(netif_ip4_netmask(netif))));
+
+#if IP_DEBUG
+  u32_t a, b, c, d, e, f;
+  a = ip4_addr_get_u32(ip4_current_dest_addr());
+  b = ip4_addr_get_u32(netif_ip4_addr(netif));
+  c = ip4_addr_get_u32(ip4_current_dest_addr()) & ip4_addr_get_u32(netif_ip4_netmask(netif));
+  d = ip4_addr_get_u32(netif_ip4_addr(netif)) & ip4_addr_get_u32(netif_ip4_netmask(netif));
+  e = ip4_addr_get_u32(ip4_current_dest_addr()) & ~ip4_addr_get_u32(netif_ip4_netmask(netif));
+  f = ip4_addr_get_u32(ip4_current_src_addr());
+
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_input: iphdr->src %"U16_F".%"U16_F".%"U16_F".%"U16_F" ",
+			   ((const u8_t*) (&f))[0], ((const u8_t*) (&f))[1],
+			   ((const u8_t*) (&f))[2], ((const u8_t*) (&f))[3]));
+  LWIP_DEBUGF(IP_DEBUG, (" iphdr->dest %"U16_F".%"U16_F".%"U16_F".%"U16_F" ",
+			   ((const u8_t*) (&a))[0], ((const u8_t*) (&a))[1],
+			   ((const u8_t*) (&a))[2], ((const u8_t*) (&a))[3]));
+  LWIP_DEBUGF(IP_DEBUG, ("netif->ip_addr %"U16_F".%"U16_F".%"U16_F".%"U16_F" \n", 
+			   ((const u8_t*) (&b))[0], ((const u8_t*) (&b))[1],
+			   ((const u8_t*) (&b))[2], ((const u8_t*) (&b))[3]));
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_input:   (%"U16_F".%"U16_F".%"U16_F".%"U16_F", ", 
+			   ((const u8_t*) (&c))[0], ((const u8_t*) (&c))[1],
+			   ((const u8_t*) (&c))[2], ((const u8_t*) (&c))[3]));
+  LWIP_DEBUGF(IP_DEBUG, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F", ", 
+			   ((const u8_t*) (&d))[0], ((const u8_t*) (&d))[1],
+			   ((const u8_t*) (&d))[2], ((const u8_t*) (&d))[3]));
+  LWIP_DEBUGF(IP_DEBUG, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F") \n", 
+			   ((const u8_t*) (&e))[0], ((const u8_t*) (&e))[1],
+			   ((const u8_t*) (&e))[2], ((const u8_t*) (&e))[3]));
+#endif
 
   /* interface is up and configured? */
   if ((netif_is_up(netif)) && (!ip4_addr_isany_val(*netif_ip4_addr(netif)))) {
@@ -629,6 +779,17 @@ ip4_input(struct pbuf *p, struct netif *inp)
        list of configured netifs. */
     if (ip4_input_accept(inp)) {
       netif = inp;
+#if IP_NAPT
+#if IP_FORWARD
+      /* try to forward IP packet on (this) interface */
+      if (inp->napt && IP_FORWARD_ALLOW_TX_ON_RX_NETIF) {
+        if (ip4_forward_local(p, (struct ip_hdr *)p->payload, inp) == ERR_OK) {
+          pbuf_free(p);
+          return ERR_OK; 
+        }
+      }
+#endif /* IP_FORWARD */
+#endif /* IP_NAPT */
     } else {
       netif = NULL;
 #if !LWIP_NETIF_LOOPBACK || LWIP_HAVE_LOOPIF
@@ -767,7 +928,7 @@ ip4_input(struct pbuf *p, struct netif *inp)
 #endif /* IP_OPTIONS_ALLOWED == 0 */
 
   /* send to upper layers */
-  LWIP_DEBUGF(IP_DEBUG, ("ip4_input: \n"));
+  LWIP_DEBUGF(IP_DEBUG, ("ip4_input: send to upper layers\n"));
   ip4_debug_print(p);
   LWIP_DEBUGF(IP_DEBUG, ("ip4_input: p->len %"U16_F" p->tot_len %"U16_F"\n", p->len, p->tot_len));
 

--- a/src/core/ipv4/ip4_napt.c
+++ b/src/core/ipv4/ip4_napt.c
@@ -71,7 +71,8 @@ struct ip_napt_entry {
   u32_t dest;  /* net */
   u16_t sport; /* net */
   u16_t dport; /* net */
-  u16_t mport; /* net */
+  u16_t msport; /* net */
+  u16_t mdport; /* net */
   u8_t proto;
   u8_t fin1 : 1;
   u8_t fin2 : 1;
@@ -123,9 +124,9 @@ napt_debug_print(void)
   if (nr_total == 0) return;
 #endif
 
-  DPRINTF(("+-----------------------+-----------------------+-------+---------+----------+\n"));
-  DPRINTF(("| src                   | dest                  | mport | flags   | age      |\n"));
-  DPRINTF(("+-----------------------+-----------------------+-------+---------+----------+\n"));
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
+  DPRINTF(("| src                   | dest                  | msport| mdport| flags   | age      |\n"));
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
   for (i = napt_list; i != NO_IDX; i = next) {
      struct ip_napt_entry *t = &ip_napt_table[i];
      next = t->next;
@@ -145,8 +146,9 @@ napt_debug_print(void)
               lwip_ntohs(t->dport)));
 
      p = t->proto;
-     DPRINTF(("| %5"U16_F" | %c%c%c%c%c%c%c | %8"U32_F" |\n",
-              lwip_ntohs(t->mport),
+     DPRINTF(("| %5"U16_F" | %5"U16_F" | %c%c%c%c%c%c%c | %8"U32_F" |\n",
+              lwip_ntohs(t->msport),
+              lwip_ntohs(t->mdport),
               (p == IP_PROTO_TCP ? 'T' : (p == IP_PROTO_UDP ? 'U' : (p == IP_PROTO_ICMP ? 'I' : '?'))),
               (t->fin1 ? 'f' : '.'),
               (t->fin2 ? 'F' : '.'),
@@ -157,7 +159,7 @@ napt_debug_print(void)
               now - t->last));
 
   }
-  DPRINTF(("+-----------------------+-----------------------+-------+---------+----------+\n"));
+  DPRINTF(("+-----------------------+-----------------------+-------+-------+---------+----------+\n"));
 }
 #endif /* NAPT_DEBUG */
 
@@ -222,6 +224,7 @@ ip_napt_enable(u32_t addr, int enable)
   } else {
     ip_napt_deinit();
   }
+  LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d\n", enable));
 }
 
 void
@@ -235,6 +238,7 @@ ip_napt_enable_no(u8_t number, int enable)
         ip_napt_init(IP_NAPT_MAX, IP_PORTMAP_MAX);
       else
         ip_napt_deinit();
+      LWIP_DEBUGF(NAPT_DEBUG, ("ip_napt set to %d on %d\n", netif->napt, netif->num));
       break;
     }
   }
@@ -378,13 +382,15 @@ ip_napt_free(struct ip_napt_entry *t)
 
 #if LWIP_TCP
 static u8_t
-ip_napt_find_port(u8_t proto, u16_t port)
+ip_napt_find_port(u8_t proto, u16_t port, u8_t dest)
 {
   int i, next;
   for (i = napt_list; i != NO_IDX; i = next) {
     struct ip_napt_entry *t = &ip_napt_table[i];
     next = t->next;
-    if (t->proto == proto && t->mport == port)
+    if (dest && t->proto == proto && t->mdport == port)
+      return 1;
+    if (!dest && t->proto == proto && t->msport == port)
       return 1;
   }
   return 0;
@@ -424,12 +430,12 @@ static u16_t
 ip_napt_new_port(u8_t proto, u16_t port)
 {
   if (PP_NTOHS(port) >= IP_NAPT_PORT_RANGE_START && PP_NTOHS(port) <= IP_NAPT_PORT_RANGE_END)
-    if (!ip_napt_find_port(proto, port) && !tcp_listening(port))
+    if (!ip_napt_find_port(proto, port,1) && !tcp_listening(port))
       return port;
   for (;;) {
     port = PP_HTONS(IP_NAPT_PORT_RANGE_START +
                     LWIP_RAND() % (IP_NAPT_PORT_RANGE_END - IP_NAPT_PORT_RANGE_START + 1));
-    if (ip_napt_find_port(proto, port))
+    if (ip_napt_find_port(proto, port, 1))
       continue;
 #if LWIP_TCP
     if (proto == IP_PROTO_TCP && tcp_listening(port))
@@ -466,13 +472,12 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
   for (i = napt_list; i != NO_IDX; i = next) {
     t = NT(i);
     next = t->next;
-    if (!dest && t->proto == proto && t->src == addr && t->sport == port) {
+    if (!dest && t->proto == proto && t->src == addr && t->sport == port && t->msport == mport) {
       t->last = now;
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
       return t;
     }
-    if (dest && t->proto == proto && t->dest == addr && t->dport == port
-        && t->mport == mport) {
+    if (dest && t->proto == proto && t->dest == addr && t->dport == port && t->mdport == mport) {
       t->last = now;
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
       return t;
@@ -484,9 +489,9 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
 }
 
 static u16_t
-ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u32_t seqno)
+ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u16_t msport, u32_t seqno)
 {
-  struct ip_napt_entry *t = ip_napt_find(proto, src, sport, 0, 0);
+  struct ip_napt_entry *t = ip_napt_find(proto, src, sport, msport, 0);
   if (t) {
     t->last = sys_now();
     t->dest = dest;
@@ -500,7 +505,7 @@ ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u32_t s
     napt_debug_print();
 #endif
 
-    return t->mport;
+    return t->mdport;
   }
   t = NT(napt_free);
   if (!t) {
@@ -522,7 +527,8 @@ ip_napt_add(u8_t proto, u32_t src, u16_t sport, u32_t dest, u16_t dport, u32_t s
     t->dest = dest;
     t->sport = sport;
     t->dport = dport;
-    t->mport = mport;
+    t->msport = msport;
+    t->mdport = mport;
     t->proto = proto;
     t->fin1 = t->fin2 = t->finack1 = t->finack2 = t->synack = t->rst = 0;
     t->src_seqno = ntohl(seqno);
@@ -781,7 +787,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     struct icmp_echo_hdr *iecho = (struct icmp_echo_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
     if (iecho->type == ICMP_ECHO) {
       /* register src addr and iecho->id and dest info */
-      ip_napt_add(IP_PROTO_ICMP, iphdr->src.addr, iecho->id, iphdr->dest.addr, iecho->id, 0);
+      ip_napt_add(IP_PROTO_ICMP, iphdr->src.addr, iecho->id, iphdr->dest.addr, iecho->id, 0, 0);
 
       ip_napt_modify_addr(iphdr, &iphdr->src, ip_2_ip4(&outp->ip_addr)->addr);
     }
@@ -808,7 +814,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
         PP_NTOHS(tcphdr->src) >= 1024) {
       /* Register new TCP session to NAPT */
       mport = ip_napt_add(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src,
-                          iphdr->dest.addr, tcphdr->dest, tcphdr->seqno);
+                          iphdr->dest.addr, tcphdr->dest, tcphdr->dest, tcphdr->seqno);
       if (mport == 0) {
 #if LWIP_ICMP
         icmp_dest_unreach(p, ICMP_DUR_PORT);
@@ -817,14 +823,14 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
       }
     } else {
       uint32_t seqno, src_seqno;
-      struct ip_napt_entry *t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, 0, 0);
+      struct ip_napt_entry *t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 0);
       if (!t || t->dest != iphdr->dest.addr || t->dport != tcphdr->dest) {
 #if LWIP_ICMP
         icmp_dest_unreach(p, ICMP_DUR_PORT);
 #endif
         return ERR_RTE; /* Drop unknown TCP session */
       }
-      mport = t->mport;
+      mport = t->mdport;
       if ((TCPH_FLAGS(tcphdr) & TCP_FIN))
         t->fin2 = 1;
       if (t->fin1 && (TCPH_FLAGS(tcphdr) & TCP_ACK))
@@ -865,7 +871,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
     if (PP_NTOHS(udphdr->src) >= 1024) {
       /* Register new UDP session */
       mport = ip_napt_add(IP_PROTO_UDP, iphdr->src.addr, udphdr->src,
-                          iphdr->dest.addr, udphdr->dest, 0);
+                          iphdr->dest.addr, udphdr->dest, udphdr->dest, 0);
       if (mport == 0)
         return ERR_RTE; /* routing err if add entry failed */
     } else {
@@ -876,7 +882,7 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
 #endif
         return ERR_RTE; /* Drop unknown UDP session */
       }
-      mport = t->mport;
+      mport = t->mdport;
     }
 
     if (mport != udphdr->src)
@@ -888,6 +894,110 @@ ip_napt_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp, struct 
 #endif
 
   return ERR_OK;
+}
+
+err_t
+ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr)
+{
+  LWIP_DEBUGF(IP_DEBUG, ("ip_napt_forward_local: start\n"));
+
+#if LWIP_TCP
+  if (IPH_PROTO(iphdr) == IP_PROTO_TCP) {
+    struct tcp_hdr *tcphdr = (struct tcp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+
+    struct ip_napt_entry *t;
+    struct ip_portmap_entry *m;
+    
+    t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 1);
+    if (t) {
+      /* packet from port-mapped dest addr/port: rewrite source to this node */
+      ip_napt_modify_port_tcp(tcphdr, 0, t->msport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_port_tcp(tcphdr, 1, t->sport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->dest, t->src);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, t->src);
+      return ERR_OK;
+    }
+
+    t = ip_napt_find(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src, tcphdr->dest, 0);
+    if (t) {
+      /* packet from port-mapped src addr/port: rewrite source to this node */
+      ip_napt_modify_port_tcp(tcphdr, 0, t->mdport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_port_tcp(tcphdr, 1, t->dport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->dest, t->dest);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, t->dest);
+      return ERR_OK;
+    }
+
+    m = ip_portmap_find(IP_PROTO_TCP, tcphdr->dest);
+    if (m) {
+      /* packet from port-mapped dest addr/port: rewrite source to this node */
+      u16_t mport = ip_napt_add(IP_PROTO_TCP, iphdr->src.addr, tcphdr->src,
+                          m->daddr, m->dport, tcphdr->dest, 0);
+      ip_napt_modify_port_tcp(tcphdr, 0, mport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->src, m->maddr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, m->maddr);
+      ip_napt_modify_port_tcp(tcphdr, 1, m->dport);
+      ip_napt_modify_addr_tcp(tcphdr, &iphdr->dest, m->daddr);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, m->daddr);
+      return ERR_OK;
+    }
+    return ERR_RTE; /* not forwarding on same netif */
+  }
+#endif
+
+#if LWIP_UDP
+  if (IPH_PROTO(iphdr) == IP_PROTO_UDP) {
+    struct udp_hdr *udphdr = (struct udp_hdr *)((u8_t *)p->payload + IPH_HL(iphdr) * 4);
+
+    struct ip_napt_entry *t;
+    struct ip_portmap_entry *m;
+    
+    t = ip_napt_find(IP_PROTO_UDP, iphdr->src.addr, udphdr->src, udphdr->dest, 1);
+    if (t) {
+      /* packet from port-mapped dest addr/port: rewrite source to this node */
+      ip_napt_modify_port_udp(udphdr, 0, t->msport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_port_udp(udphdr, 1, t->sport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->dest, t->src);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, t->src);
+      return ERR_OK;
+    }
+
+    t = ip_napt_find(IP_PROTO_UDP, iphdr->src.addr, udphdr->src, udphdr->dest, 0);
+    if (t) {
+      /* packet from port-mapped src addr/port: rewrite source to this node */
+      ip_napt_modify_port_udp(udphdr, 0, t->mdport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, iphdr->dest.addr);
+      ip_napt_modify_port_udp(udphdr, 1, t->dport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->dest, t->dest);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, t->dest);
+      return ERR_OK;
+    }
+
+    m = ip_portmap_find(IP_PROTO_UDP, udphdr->dest);
+    if (m) {
+      /* packet from port-mapped dest addr/port: rewrite source to this node */
+      u16_t mport = ip_napt_add(IP_PROTO_UDP, iphdr->src.addr, udphdr->src,
+                          m->daddr, m->dport, udphdr->dest, 0);
+      ip_napt_modify_port_udp(udphdr, 0, mport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->src, m->maddr);
+      ip_napt_modify_addr(iphdr, &iphdr->src, m->maddr);
+      ip_napt_modify_port_udp(udphdr, 1, m->dport);
+      ip_napt_modify_addr_udp(udphdr, &iphdr->dest, m->daddr);
+      ip_napt_modify_addr(iphdr, &iphdr->dest, m->daddr);
+      return ERR_OK;
+    }
+    return ERR_RTE; /* not forwarding on same netif */
+  }
+#endif
+
+  return ERR_RTE;
 }
 
 static void

--- a/src/include/lwip/ip4_napt.h
+++ b/src/include/lwip/ip4_napt.h
@@ -65,6 +65,7 @@ extern "C" {
 #define NAPT_TMR_INTERVAL 2000
 #endif
 
+#if IP_FORWARD_ALLOW_TX_ON_RX_NETIF
 /**
  * NAPT for a forwarded packet. It checks whether we need NAPT and modify
  * the packet source address and port if needed.
@@ -75,6 +76,7 @@ extern "C" {
  */
 err_t
 ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr);
+#endif
 
 /**
  * NAPT for a forwarded packet. It checks weather we need NAPT and modify

--- a/src/include/lwip/ip4_napt.h
+++ b/src/include/lwip/ip4_napt.h
@@ -66,6 +66,17 @@ extern "C" {
 #endif
 
 /**
+ * NAPT for a forwarded packet. It checks whether we need NAPT and modify
+ * the packet source address and port if needed.
+ *
+ * @param p the packet to forward (p->payload points to IP header)
+ * @param iphdr the IP header of the input packet
+ * @return ERR_OK if packet should be sent, or ERR_RTE if it should be dropped
+ */
+err_t
+ip_napt_forward_local(struct pbuf *p, struct ip_hdr *iphdr);
+
+/**
  * NAPT for a forwarded packet. It checks weather we need NAPT and modify
  * the packet source address and port if needed.
  *


### PR DESCRIPTION
As currently written in ESP-IDF 4.4.1 (lwip 2.1.2), lwip cannot possibly forward back onto the same network (what I need) without errors. I will explain. If A is the source, B the port forwarder and C the destination, as currently written ip4_forward only modifies the destination in the packet. So a packet will be forwarded with source as A and destination as C. This is okay if the packet is going to a different network than the source. If the destination is on the same network (netif) as the source then when C receives the packet it will return directly to A. Then A will drop the packet because it does not have any known connections with C. A had a connection open to B, not C. (I verified this behavior with wireshark.) My update to lwip fixes this. If the packet is forwarded to the same network as the source, my update will have destination C return to B which will then return to A. All traffic is as expected, all connections are properly handled.

Note that IP_FORWARD, IP_NAPT and IP_FORWARD_ALLOW_TX_ON_RX_NETIF must all be enabled. I had to do manually enable IP_FORWARD_ALLOW_TX_ON_RX_NETIF in opt.h since menuconfig does not currently handle this.

@david-cermak I closed the old and created a new pull request for adding port forwarding on the same netif. All check unit tests complete with no errors.
 