### PR TITLE
dns: fix init with only IPv4 enabled (IDFGH-11392)

### DIFF
--- a/src/core/dns.c
+++ b/src/core/dns.c
@@ -325,7 +325,9 @@ dns_init(void)
   /* initialize fallback dns DNS server address */
   ip_addr_t dnsserver;
   FALLBACK_DNS_SERVER_ADDRESS(&dnsserver);
+#if LWIP_IPV4 && LWIP_IPV6
   dnsserver.type = IPADDR_TYPE_V4;
+#endif
   dns_setserver(DNS_FALLBACK_SERVER_INDEX, &dnsserver);
 #endif /* FALLBACK_DNS_SERVER_ADDRESS */
 


### PR DESCRIPTION
When defining `FALLBACK_DNS_SERVER_ADDRESS` in a project where only `LWIP_IPV4` is enabled, compiling `dns_init` will result in a compilation error: 

```
esp-idf/components/lwip/lwip/src/core/dns.c: In function 'dns_init':
esp-idf/components/lwip/lwip/src/core/dns.c:328:12: error: 'ip_addr_t' {aka 'struct ip4_addr'} has no member named 'type'
   dnsserver.type = IPADDR_TYPE_V4;
```

This is due to the fact that `ip_addr_t` is defined as 

```
typedef struct ip_addr {
  union {
    ip6_addr_t ip6;
    ip4_addr_t ip4;
  } u_addr;
  /** @ref lwip_ip_addr_type */
  u8_t type;
} ip_addr_t;
```

only if IPv4 and IPv6 support are enabled at the same time. 

In the case where only IPv4 support is enabled, the definition of `ip_addr_t` is

```
struct ip4_addr {
  u32_t addr;
};

typedef struct ip4_addr ip4_addr_t;

typedef ip4_addr_t ip_addr_t;
```

which lacks the `type` field. 

This PR aims to fix this and make it compile for our scenario. 