### PR TITLE
Added MEMP_MEM_MALLOC_CHECK_MAX option

### DIFF
--- a/src/core/memp.c
+++ b/src/core/memp.c
@@ -251,8 +251,20 @@ do_memp_malloc_pool_fn(const struct memp_desc *desc, const char *file, const int
   SYS_ARCH_DECL_PROTECT(old_level);
 
 #if MEMP_MEM_MALLOC
+#if MEMP_MEM_MALLOC_CHECK_MAX
+  if (*desc->remaining) {
+    memp = (struct memp *)mem_malloc(MEMP_SIZE + MEMP_ALIGN_SIZE(desc->size));
+    if (memp != NULL) {
+      *desc->remaining -= 1;
+    }
+  } else {
+    memp = NULL;
+  }
+  SYS_ARCH_PROTECT(old_level);
+#else /* MEMP_MEM_MALLOC_CHECK_MAX */
   memp = (struct memp *)mem_malloc(MEMP_SIZE + MEMP_ALIGN_SIZE(desc->size));
   SYS_ARCH_PROTECT(old_level);
+#endif /* MEMP_MEM_MALLOC_CHECK_MAX */
 #else /* MEMP_MEM_MALLOC */
   SYS_ARCH_PROTECT(old_level);
 
@@ -378,6 +390,9 @@ do_memp_free_pool(const struct memp_desc *desc, void *mem)
 #endif
 
 #if MEMP_MEM_MALLOC
+#if MEMP_MEM_MALLOC_CHECK_MAX
+  *desc->remaining += 1;
+#endif
   LWIP_UNUSED_ARG(desc);
   SYS_ARCH_UNPROTECT(old_level);
   mem_free(memp);

--- a/src/include/lwip/memp.h
+++ b/src/include/lwip/memp.h
@@ -68,6 +68,22 @@ extern const struct memp_desc* const memp_pools[MEMP_MAX];
 
 #if MEMP_MEM_MALLOC
 
+#if MEMP_MEM_MALLOC_CHECK_MAX
+
+#define LWIP_MEMPOOL_DECLARE(name,num,size,desc) \
+  LWIP_MEMPOOL_DECLARE_STATS_INSTANCE(memp_stats_ ## name) \
+    \
+  static u16_t memp_remaining_ ## name = (num); \
+    \
+  const struct memp_desc memp_ ## name = { \
+    DECLARE_LWIP_MEMPOOL_DESC(desc) \
+    LWIP_MEMPOOL_DECLARE_STATS_REFERENCE(memp_stats_ ## name) \
+    LWIP_MEM_ALIGN_SIZE(size), \
+    &memp_remaining_ ## name \
+  };
+
+#else /* MEMP_MEM_MALLOC_CHECK_MAX */
+
 #define LWIP_MEMPOOL_DECLARE(name,num,size,desc) \
   LWIP_MEMPOOL_DECLARE_STATS_INSTANCE(memp_stats_ ## name) \
   const struct memp_desc memp_ ## name = { \
@@ -75,6 +91,7 @@ extern const struct memp_desc* const memp_pools[MEMP_MAX];
     LWIP_MEMPOOL_DECLARE_STATS_REFERENCE(memp_stats_ ## name) \
     LWIP_MEM_ALIGN_SIZE(size) \
   };
+#endif /* MEMP_MEM_MALLOC_CHECK_MAX */
 
 #else /* MEMP_MEM_MALLOC */
 

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -272,6 +272,14 @@
 #endif
 
 /**
+ * MEMP_MEM_MALLOC_CHECK_MAX==1: Honor pool limits even when pool allocation is not used.
+ * Used for controlling maximum memory usage of LWIP stack.
+ */
+#if !defined MEMP_MEM_MALLOC_CHECK_MAX || defined __DOXYGEN__
+#define MEMP_MEM_MALLOC_CHECK_MAX       0
+#endif
+
+/**
  * MEMP_MEM_INIT==1: Force use of memset to initialize pool memory.
  * Useful if pool are moved in uninitialized section of memory. This will ensure
  * default values in pcbs struct are well initialized in all conditions.

--- a/src/include/lwip/priv/memp_priv.h
+++ b/src/include/lwip/priv/memp_priv.h
@@ -128,6 +128,11 @@ struct memp_desc {
   /** First free element of each pool. Elements form a linked list. */
   struct memp **tab;
 #endif /* MEMP_MEM_MALLOC */
+
+#if MEMP_MEM_MALLOC_CHECK_MAX
+  /** Remaining number of buffers */
+  u16_t *remaining;
+#endif /* MEMP_MEM_MALLOC_CHECK_MAX */
 };
 
 #if defined(LWIP_DEBUG) || MEMP_OVERFLOW_CHECK || LWIP_STATS_DISPLAY


### PR DESCRIPTION
This option adds functionality to enforce max memory usage in the same way it is enforced by standard memory pool allocator.

Everything is #if guarded by MEMP_MEM_MALLOC_CHECK_MAX which is disabled by default.

During testing we have found some problem with LWIP_NUM_SYS_TIMEOUT_INTERNAL, as there are missing few chunks for timers.
On the other hand, this makes options like CONFIG_LWIP_MAX_ACTIVE_TCP work. In general it puts to work all MEMP_NUM_* options which do nothing in current state.

Adding MEMP_MEM_MALLOC_CHECK_MAX to lwipopts.h file in IDF repository is needed to make this change effective. This can be done through config option.