### PR TITLE
sntp: Add retry timeout delay on DNS resolution failure (IDFGH-17680)

### DIFF
--- a/src/apps/sntp/sntp.c
+++ b/src/apps/sntp/sntp.c
@@ -595,7 +595,8 @@ sntp_dns_found(const char *hostname, const ip_addr_t *ipaddr, void *arg)
   } else {
     /* DNS resolving failed -> try another server */
     LWIP_DEBUGF(SNTP_DEBUG_WARN_STATE, ("sntp_dns_found: Failed to resolve server address resolved, trying next server\n"));
-    sntp_try_next_server(NULL);
+    sys_untimeout(sntp_try_next_server, NULL);
+    sys_timeout((u32_t)SNTP_RETRY_TIMEOUT, sntp_try_next_server, NULL);
   }
 }
 #endif /* SNTP_SERVER_DNS */


### PR DESCRIPTION
Introduce a delay before retrying DNS resolution for invalid NTP server names to prevent aggressive retry loops. Failed DNS queries now respect the configured SNTP_RETRY_TIMEOUT interval, reducing unnecessary network/CPU load while preserving server fallback behavior.

Fixes issue with persistent DNS queries for invalid NTP server names.

patch to upstream: https://savannah.nongnu.org/patch/?10518