### PR TITLE
fix(sockets): report actual address length on getpeername/getsockname truncation (IDFGH-17941)

### DIFF
--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -2815,10 +2815,13 @@ lwip_getaddrname(int s, struct sockaddr *name, socklen_t *namelen, u8_t local)
   ip_addr_debug_print_val(SOCKETS_DEBUG, naddr);
   LWIP_DEBUGF(SOCKETS_DEBUG, (" port=%"U16_F")\n", port));
 
-  if (*namelen > IPADDR_SOCKADDR_GET_LEN(&saddr)) {
-    *namelen = IPADDR_SOCKADDR_GET_LEN(&saddr);
-  }
-  MEMCPY(name, &saddr, *namelen);
+  /* Copy at most *namelen bytes into the caller's buffer, but always
+   * report the actual address length back via *namelen, even if the
+   * caller's buffer was too small to hold the whole address - this
+   * matches the POSIX getsockname()/getpeername() contract and lets
+   * the caller detect truncation. */
+  MEMCPY(name, &saddr, LWIP_MIN(*namelen, IPADDR_SOCKADDR_GET_LEN(&saddr)));
+  *namelen = IPADDR_SOCKADDR_GET_LEN(&saddr);
 
   set_errno(0);
   done_socket(sock);


### PR DESCRIPTION
## Summary

Fixes espressif/esp-idf#18161. `lwip_getaddrname()` (shared implementation behind `lwip_getpeername()`/`lwip_getsockname()`) only shrinks `*namelen` when the caller's buffer is *larger* than the actual address:

```c
if (*namelen > IPADDR_SOCKADDR_GET_LEN(&saddr)) {
    *namelen = IPADDR_SOCKADDR_GET_LEN(&saddr);
}
MEMCPY(name, &saddr, *namelen);
```

If the caller's buffer is *smaller* than the actual address — e.g. the reporter's case: a dual-stack (`LWIP_IPV4 && LWIP_IPV6`) socket where the peer turns out to be an IPv4-mapped IPv6 address, so the real `sockaddr_in6`-sized address doesn't fit in a `sizeof(struct sockaddr_in)` buffer — `*namelen` is copied from as-is and never updated. The caller gets a truncated address with `*namelen` still showing the original (too-small) size, with no way to detect that truncation happened.

## Fix

POSIX requires `getsockname()`/`getpeername()` to always store the actual address length in `*namelen`, precisely so a caller whose buffer is too small can detect it (and, if it cares, retry with a bigger buffer). Always set `*namelen` to the real address length, while still only `MEMCPY`-ing up to whichever of `*namelen`/actual length is smaller, so the caller's buffer is never overrun.

## Testing

I don't have real ESP32 hardware/dual-stack setup available to reproduce this end to end, so I wrote a standalone host-C reproduction of just this snippet (stand-in `IPADDR_SOCKADDR_GET_LEN` returning a fixed 28-byte "address"), simulating a caller passing a 16-byte buffer:

- **Before fix**: `*namelen` stays `16` after the call (doesn't report the real 28-byte length).
- **After fix**: `*namelen` comes back as `28`, matching POSIX's truncation-reporting contract, while the actual `MEMCPY` still only writes the 16 bytes that fit.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.