### PR TITLE
fix(tcp): poll pending close on LAST_ACK completion to avoid lost wakeup (IDFGH-17950)

### DIFF
--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -1062,6 +1062,18 @@ tcp_process(struct tcp_pcb *pcb)
         LWIP_DEBUGF(TCP_DEBUG, ("TCP connection closed: LAST_ACK %"U16_F" -> %"U16_F".\n", inseg.tcphdr->src, inseg.tcphdr->dest));
         /* bugfix #21699: don't set pcb->state to CLOSED here or we risk leaking segments */
         recv_flags |= TF_CLOSED;
+        /* This ACK only acknowledges our own FIN (tcp_seg::len is always 0
+           for a FIN-only segment, see tcp_enqueue_flags()), so recv_acked
+           stays 0 and the TCP_EVENT_SENT sent-callback below is never
+           invoked. Without an explicit poll here, a netconn waiting on
+           lwip_netconn_do_close_internal() (registered via tcp_poll() while
+           closing was still pending) is never given a chance to notice
+           that the close has now completed before tcp_input_delayed_close()
+           frees this pcb, and the application's close() call hangs forever.
+           Mirror the TCP_POLL_LINGERING_CLOSE(pcb) call already used for
+           the equivalent FIN_WAIT_1/FIN_WAIT_2/CLOSING -> TIME_WAIT
+           transitions above. */
+        TCP_POLL_LINGERING_CLOSE(pcb);
       }
       break;
     default:


### PR DESCRIPTION
## Description

Fixes #84.

`tcp_process()`'s `FIN_WAIT_1 -> TIME_WAIT`, `FIN_WAIT_2 -> TIME_WAIT` and `CLOSING -> TIME_WAIT` transitions (`src/core/tcp_in.c`) all call `TCP_POLL_LINGERING_CLOSE(pcb)` right after completing the transition:

```c
case CLOSING:
  ...
    pcb->state = TIME_WAIT;
    TCP_REG(&tcp_tw_pcbs, pcb);
    TCP_POLL_LINGERING_CLOSE(pcb);   // <-- present
```

That macro (added by 88136ab1, "tcp_in: Fix incomplete closure if linger active") synchronously invokes the pcb's `poll` callback, which - while a netconn `close()` is still pending - is `poll_tcp()` in `api_msg.c`. `poll_tcp()` calls `lwip_netconn_do_close_internal()`, which is what actually posts `op_completed_sem` and wakes the application task blocked in `close()`.

The `LAST_ACK -> TF_CLOSED` transition is missing the same call:

```c
case LAST_ACK:
  tcp_receive(pcb);
  if ((flags & TCP_ACK) && ackno == pcb->snd_nxt && pcb->unsent == NULL) {
    ...
    recv_flags |= TF_CLOSED;   // no TCP_POLL_LINGERING_CLOSE(pcb) here
  }
  break;
```

Why this matters specifically for `LAST_ACK` (and not just "eventually the periodic poll timer will catch it"): a FIN-only segment always has `tcp_seg::len == 0` (see the `"seg->len == 0"` assert in `tcp_enqueue_flags()`), so when the incoming ACK only acknowledges our own FIN, `recv_acked` stays `0` in `tcp_input()` and the `TCP_EVENT_SENT` sent-callback is never invoked either. And since `tcp_close()` unconditionally sets `TF_RXCLOSED` on the pcb, `tcp_input_delayed_close()` also skips `TCP_EVENT_ERR` before freeing the pcb (`tcp_pcb_remove()` + `tcp_free()`), which happens synchronously later in the very same `tcp_input()` call. So *no* callback fires at all before the pcb is gone - not a leak, a permanent hang of whatever task is blocked in `close()`.

This is exactly the "Case C" packet trace reported in #84: remote sends its own FIN first, local side still has an unacked data segment in flight but nothing left unsent; by the time the peer's ACK of our FIN arrives, that ACK carries no new data, so today's code never re-checks whether closing has completed.

## Fix

Add the same `TCP_POLL_LINGERING_CLOSE(pcb)` call to the `LAST_ACK` case, mirroring the other three transitions, so a pending close gets one last synchronous chance to complete before the pcb is freed.

## Testing

I don't have a live browser/WebSocket setup to reproduce the original multi-hour hang end-to-end, so I instead isolated the exact decision point: whether *anything* invokes the pcb's poll/sent callback before `tcp_free()` runs. I extracted the real macros (`TCP_EVENT_POLL`, `TCP_POLL_LINGERING_CLOSE`) and the real `CLOSING` vs. `LAST_ACK` switch-case control flow from this tree into a small standalone C program, with a stand-in `netconn`/semaphore and `poll_tcp()`/`lwip_netconn_do_close_internal()` matching `api_msg.c`'s wiring:

- **Before this change**: `CLOSING` fires the poll/close-completion callback once (semaphore posted, `close()` would return); `LAST_ACK` fires it **zero** times before the pcb is marked freed (semaphore never posted - `close()` hangs forever). This reproduces the reported bug.
- **After adding `TCP_POLL_LINGERING_CLOSE(pcb)` to `LAST_ACK`**: both paths fire the callback once, before free.

I also syntax/type-checked the actual in-tree edit against the real headers/macros (not just the standalone model):

```
gcc -fsyntax-only -Wall -Wextra -Isrc/include -Icontrib/ports/unix/lib \
    -Icontrib/ports/unix/port/include src/core/tcp_in.c
gcc -fsyntax-only -Wall -Wextra -Isrc/include -Icontrib/ports/unix/lib \
    -Icontrib/ports/unix/port/include -DESP_LWIP=1 -DLWIP_SO_LINGER=1 \
    src/core/tcp_in.c
```

Both compile cleanly with no warnings.

I did not run the full `check`-based unit test suite (`contrib/ports/unix/check`) locally since it depends on the `check` framework, which isn't set up in my environment.

## Generative AI

I used generative AI tools (Claude Code) to research the root cause, diagnose the missing code path, and draft this change. I reviewed the analysis and the resulting diff myself and take responsibility for the code and this description.

## Checklist

- [x] This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed. (none required - internal fix, no API/behavior surface change beyond fixing the hang)
- [ ] Tests are updated or added as necessary. (see Testing section - standalone reproduction provided instead; happy to add a proper unit test under `test/unit/tcp` if maintainers want one in a particular style)
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean - commits are squashed to the minimum necessary.
